### PR TITLE
Use arrows to quickly move variables and steps

### DIFF
--- a/Controller/Controller/Data/Channels/ChannelBasicController.cs
+++ b/Controller/Controller/Data/Channels/ChannelBasicController.cs
@@ -116,17 +116,28 @@ namespace Controller.Data.Channels
         {
             int index = Steps.IndexOf(step);
 
+            // We need to move the controllers, the models, recalculate the start time of the effected steps, and notify UI of change
             if (index > 1 && leftRight == LeftRightEnum.Left)
             {
+                StepBasicController previousStep = (StepBasicController)Steps[index - 1];
                 Steps.Move(index, index - 1);
                 Model.Steps.Move(index - 1, index - 2);
+                Model.Steps[index - 2].SetStartTime(StartTimeOf(step));
+                Model.Steps[index - 1].SetStartTime(StartTimeOf(previousStep));
+                step.UpdateProperty("StartTime");
+                previousStep.UpdateProperty("StartTime");
                 CopyToBuffer();
             }
 
             if (index < Steps.Count - 1 && leftRight == LeftRightEnum.Right)
             {
+                StepBasicController nextStep = (StepBasicController)Steps[index + 1];
                 Steps.Move(index, index + 1);
                 Model.Steps.Move(index - 1, index);
+                Model.Steps[index].SetStartTime(StartTimeOf(step));
+                Model.Steps[index - 1].SetStartTime(StartTimeOf(nextStep));
+                step.UpdateProperty("StartTime");
+                nextStep.UpdateProperty("StartTime");
                 CopyToBuffer();
             }
         }

--- a/Controller/Controller/Data/Steps/StepBasicController.cs
+++ b/Controller/Controller/Data/Steps/StepBasicController.cs
@@ -489,9 +489,8 @@ namespace Controller.Data.Steps
         {
             get
             {
-                double startTime = GetStartTime();
-                _model.SetStartTime(startTime);
-
+                double startTime = ((ChannelBasicController)Parent).StartTimeOf(this);
+                
                 return startTime;
             }
         }
@@ -878,7 +877,6 @@ namespace Controller.Data.Steps
         public void DoMoveLeft(object parameter)
         {
             _parent.MoveStep(this, ChannelBasicController.LeftRightEnum.Left);
-            GetStartTime();
         }
 
         /// <summary>
@@ -1066,17 +1064,6 @@ namespace Controller.Data.Steps
             }
         }
 
-
-        /// <summary>
-        /// Gets the start time.
-        /// </summary>
-        /// <returns>The start time in millis.</returns>
-        private double GetStartTime()
-        {
-            return ((ChannelBasicController)Parent).StartTimeOf(this);
-            //Console.WriteLine("###########" + output + "#################");
-
-        }
 
         /// <summary>
         /// Gets the value of the step

--- a/Controller/Controller/Variables/VariableController.cs
+++ b/Controller/Controller/Variables/VariableController.cs
@@ -533,7 +533,7 @@ namespace Controller.Variables
         /// <returns><c>true</c> if the name is already in use; <c>false</c> therwise.</returns>
         private bool IsNameUsed(string variableName)
         {
-            foreach (VariableController variable in _parent.Variables)
+            foreach (VariableModel variable in _parent._variablesModel.VariablesList)
             {
                 if (variable.VariableName.Equals(variableName) && !variable.Equals(this))
                 {

--- a/Controller/Controller/Variables/VariablesController.cs
+++ b/Controller/Controller/Variables/VariablesController.cs
@@ -619,10 +619,8 @@ namespace Controller.Variables
                 PropertyChanged(this, new PropertyChangedEventArgs("VariablesIterator"));
                 PropertyChanged(this, new PropertyChangedEventArgs("VariablesDynamic"));
             }
-            if (VariablesListChanged != null)
-            {
-                VariablesListChanged(this, new VariablesChangedEventArgs() { RefreshStatics = true, RefreshIterators = true, RefreshDynamics = true });
-            }
+
+            VariablesListChanged?.Invoke(this, new VariablesChangedEventArgs() { RefreshStatics = true, RefreshIterators = true, RefreshDynamics = true });
         }
 
         public void UpdateVariablesListNoValues()//This function deletes the focus of an input field

--- a/Controller/Controller/Variables/VariablesController.cs
+++ b/Controller/Controller/Variables/VariablesController.cs
@@ -1116,10 +1116,7 @@ namespace Controller.Variables
 
         public void UpdateWindowsList()
         {
-            if (PropertyChanged != null)
-            {
-                PropertyChanged(this, new PropertyChangedEventArgs("WindowsList"));
-            }
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("WindowsList"));
         }
 
         #region IController Members

--- a/Controller/Controller/Variables/VariablesController.cs
+++ b/Controller/Controller/Variables/VariablesController.cs
@@ -21,7 +21,7 @@ using PythonUtils.ScriptExecution;
 
 namespace Controller.Variables
 {
-    public class VariablesChangedEventArgs:EventArgs
+    public class VariablesChangedEventArgs : EventArgs
     {
         public bool RefreshStatics { set; get; }
         public bool RefreshIterators { set; get; }
@@ -78,7 +78,7 @@ namespace Controller.Variables
         public RootModel _rootModel;
         public VariablesModel _variablesModel;
         private readonly OutputHandler _outputHandler;
-       
+
         public int numberOfIterations;
 
         private Dictionary<int, bool> groupsExpandState;
@@ -133,7 +133,7 @@ namespace Controller.Variables
 
 
         // ******************** properties ********************
-        
+
         public ObservableCollection<ShowableWindow> WindowsList
         {
             get
@@ -174,9 +174,9 @@ namespace Controller.Variables
         {
             List<MenuItem> menuList = new List<MenuItem>();
             MenuItem item;
-            List<KeyValuePair<int, string>> dictionaryAsList = new List<KeyValuePair<int,string>>(GroupNames);
+            List<KeyValuePair<int, string>> dictionaryAsList = new List<KeyValuePair<int, string>>(GroupNames);
             dictionaryAsList.Sort(
-                (item1, item2)=>
+                (item1, item2) =>
                 {
                     return item1.Value.CompareTo(item2.Value);
                 }
@@ -272,7 +272,7 @@ namespace Controller.Variables
                                                                  select tempVarController);
             }
         }
-        public  ObservableCollection<VariableController> VariablesIterator
+        public ObservableCollection<VariableController> VariablesIterator
         {
             get
             {
@@ -439,7 +439,7 @@ namespace Controller.Variables
             }
             numberOfIterations = count;
             _outputHandler.NumberOfIterations = count;
-           
+
         }
 
         /// <summary>
@@ -496,107 +496,84 @@ namespace Controller.Variables
             evaluate(null);
         }
 
-        public void moveUp(VariableController variable)
+        public void moveUp(VariableController variableController)
         {
-            DateTime first = DateTime.Now;
-            if (variable.TypeOfVariable == VariableType.VariableTypeIterator || variable.TypeOfVariable == VariableType.VariableTypeDynamic)
+            if (variableController.TypeOfVariable == VariableType.VariableTypeIterator
+                || variableController.TypeOfVariable == VariableType.VariableTypeDynamic)
             {
-                if (_variablesModel.VariablesList.IndexOf(variable._model) > 0)
+                int currentModelIndex = _variablesModel.VariablesList.IndexOf(variableController._model);
+
+                if (currentModelIndex > 0)
                 {
-                    VariableModel tempVar =
-                        _variablesModel.VariablesList[_variablesModel.VariablesList.IndexOf(variable._model) - 1];
-                    while (_variablesModel.VariablesList.IndexOf(tempVar) >= 0)
+                    // find the variable to swap with   
+                    VariableModel previousVariable = null;
+                    int previousModelIndex = currentModelIndex;
+
+                    do
                     {
-                        //System.Console.Write("new index: {0}\n", _variablesModel.VariablesList.IndexOf(tempVar));
-                        if (tempVar.TypeOfVariable.Equals(variable.TypeOfVariable))
-                        {
-                            VariableModel tempModel =
-                                _variablesModel.VariablesList[_variablesModel.VariablesList.IndexOf(variable._model)];
-                            int indexA = _variablesModel.VariablesList.IndexOf(variable._model);
-                            int indexB = _variablesModel.VariablesList.IndexOf(tempVar);
-                            _variablesModel.VariablesList[indexA] = tempVar;
-                            _variablesModel.VariablesList[indexB] = tempModel;
-                            //_variablesModel.VariablesList[_variablesModel.VariablesList.IndexOf(variable._model)] = _variablesModel.VariablesList[_variablesModel.VariablesList.IndexOf(tempVar)];
-                            //_variablesModel.VariablesList[_variablesModel.VariablesList.IndexOf(tempVar)] = _variablesModel.VariablesList[_variablesModel.VariablesList.IndexOf(tempModel)];
-                            //System.Console.Write("Ok, new index! Variables swapped!\n");
-                            /*Variable.Clear();
-                        foreach (VariableModel var in _variablesModel.VariablesList)
-                        {
-                            Variables.Add(new VariableController(var, this));
-                        }*/
-                            updatIterators();
-                            updateDynamics();
-                            countTotalNumberOfIterations();
-                            break;
-                        }
-                        if (_variablesModel.VariablesList.IndexOf(tempVar) - 1 >= 0)
-                        {
-                            tempVar = _variablesModel.VariablesList[_variablesModel.VariablesList.IndexOf(tempVar) - 1];
-                        }
-                        else
-                        {
-                            break;
-                        }
+                        --previousModelIndex;
+                        previousVariable = _variablesModel.VariablesList[previousModelIndex];
+                    }
+                    while (!previousVariable.TypeOfVariable.Equals(variableController.TypeOfVariable) && previousModelIndex > 0);
+
+                    // if we managed to find a suitable step, swap it with the current one
+                    if (previousModelIndex > 0)
+                    {
+                        VariableModel currentVariable = _variablesModel.VariablesList[currentModelIndex];
+                        _variablesModel.VariablesList[currentModelIndex] = previousVariable;
+                        _variablesModel.VariablesList[previousModelIndex] = currentVariable;
+                        updatIterators();
+                        updateDynamics();
+                        countTotalNumberOfIterations();
                     }
                 }
             }
-
-            if (variable.TypeOfVariable == VariableType.VariableTypeStatic)
+            else if (variableController.TypeOfVariable == VariableType.VariableTypeStatic)
             {
-                if (variable.GroupIndex > 0)
+                if (variableController.GroupIndex > 0)
                 {
-                    variable.GroupIndex--;
+                    variableController.GroupIndex--;
                     updateStatics();
                 }
             }
-            /*DateTime last = DateTime.Now;
-            TimeSpan span = last - first;
-            System.Console.WriteLine("End");
-            System.Console.WriteLine("Time: {0}", span.TotalMilliseconds);*/
         }
 
-        public void moveDown(VariableController variable)
+        public void moveDown(VariableController variableController)
         {
-            if (variable.TypeOfVariable == VariableType.VariableTypeIterator || variable.TypeOfVariable == VariableType.VariableTypeDynamic)
+            if (variableController.TypeOfVariable == VariableType.VariableTypeIterator
+                || variableController.TypeOfVariable == VariableType.VariableTypeDynamic)
             {
-                if (_variablesModel.VariablesList.IndexOf(variable._model) < _variablesModel.VariablesList.Count - 1)
+                int currentModelIndex = _variablesModel.VariablesList.IndexOf(variableController._model);
+
+                if (currentModelIndex < _variablesModel.VariablesList.Count - 1)
                 {
-                    VariableModel tempVar =
-                        _variablesModel.VariablesList[_variablesModel.VariablesList.IndexOf(variable._model) + 1];
-                    while (_variablesModel.VariablesList.IndexOf(tempVar) < _variablesModel.VariablesList.Count)
+                    // find the variable to swap with   
+                    VariableModel nextVariable = null;
+                    int nextModelIndex = currentModelIndex;
+
+                    do
                     {
-                        if (tempVar.TypeOfVariable.Equals(variable.TypeOfVariable))
-                        {
-                            VariableModel tempModel =
-                                _variablesModel.VariablesList[_variablesModel.VariablesList.IndexOf(variable._model)];
-                            int indexA = _variablesModel.VariablesList.IndexOf(variable._model);
-                            int indexB = _variablesModel.VariablesList.IndexOf(tempVar);
-                            _variablesModel.VariablesList[indexA] = tempVar;
-                            _variablesModel.VariablesList[indexB] = tempModel;
-                            /*Variables.Clear();
-                        foreach (VariableModel var in _variablesModel.VariablesList)
-                        {
-                            Variables.Add(new VariableController(var, this));
-                        }*/
-                            updatIterators();
-                            updateDynamics();
-                            countTotalNumberOfIterations();
-                            break;
-                        }
-                        if (_variablesModel.VariablesList.IndexOf(tempVar) + 1 < _variablesModel.VariablesList.Count)
-                        {
-                            tempVar = _variablesModel.VariablesList[_variablesModel.VariablesList.IndexOf(tempVar) + 1];
-                        }
-                        else
-                        {
-                            break;
-                        }
+                        ++nextModelIndex;
+                        nextVariable = _variablesModel.VariablesList[nextModelIndex];
+                    }
+                    while (!nextVariable.TypeOfVariable.Equals(variableController.TypeOfVariable)
+                        && nextModelIndex < _variablesModel.VariablesList.Count - 1);
+
+                    // if we managed to find a suitable step, swap it with the current one
+                    if (nextModelIndex < _variablesModel.VariablesList.Count - 1)
+                    {
+                        VariableModel currentVariable = _variablesModel.VariablesList[currentModelIndex];
+                        _variablesModel.VariablesList[currentModelIndex] = nextVariable;
+                        _variablesModel.VariablesList[nextModelIndex] = currentVariable;
+                        updatIterators();
+                        updateDynamics();
+                        countTotalNumberOfIterations();
                     }
                 }
             }
-            if (variable.TypeOfVariable == VariableType.VariableTypeStatic)
+            if (variableController.TypeOfVariable == VariableType.VariableTypeStatic)
             {
-                variable.GroupIndex++;
+                variableController.GroupIndex++;
                 updateStatics();
             }
         }
@@ -644,7 +621,7 @@ namespace Controller.Variables
             }
             if (VariablesListChanged != null)
             {
-                VariablesListChanged(this, new VariablesChangedEventArgs() { RefreshStatics = true, RefreshIterators=true, RefreshDynamics=true});
+                VariablesListChanged(this, new VariablesChangedEventArgs() { RefreshStatics = true, RefreshIterators = true, RefreshDynamics = true });
             }
         }
 
@@ -790,11 +767,11 @@ namespace Controller.Variables
             variable.TypeOfVariable = VariableType.VariableTypeStatic;
             Variables.Add(variable);
 
-            if(!GroupNames.ContainsKey(0))
+            if (!GroupNames.ContainsKey(0))
             {
                 GroupNames.Add(0, "Default Group");
 
-                if(!GroupsExpandState.ContainsKey(0))
+                if (!GroupsExpandState.ContainsKey(0))
                     GroupsExpandState.Add(0, true);
             }
             //UpdateSpecificVarialbesCollection(VariableType.VariableTypeStatic);
@@ -832,34 +809,34 @@ namespace Controller.Variables
             //UpdateSpecificVarialbesCollection(VariableType.VariableTypeDynamic);
             UpdateVariablesList();
         }
-        
-      
+
+
         public void ResetIteratorValues()
         {
             // Ebaa 18.06.2018
             // prevent inconsistencies and multiple updates on the buffer
-           // Object bufferUpdateLock = VariableUpdateStart();
+            // Object bufferUpdateLock = VariableUpdateStart();
             foreach (VariableController iterator in VariablesIterator)
             {
-               
+
                 iterator.VariableValue = iterator.VariableStartValue;
 
-               // //test 11.06
-               // VariableModel VariableModelToBeReset = _outputHandler.Model.Data.variablesModel.VariablesList.Find(x => x.VariableName == iterator._model.VariableName);
+                // //test 11.06
+                // VariableModel VariableModelToBeReset = _outputHandler.Model.Data.variablesModel.VariablesList.Find(x => x.VariableName == iterator._model.VariableName);
 
 
                 ////test 11.06
-               // if (VariableModelToBeReset != null)
-              //  {
+                // if (VariableModelToBeReset != null)
+                //  {
 
-             //      VariableModelToBeReset.VariableValue = iterator.VariableStartValue;
-              //  }
-               ////// MessageBox.Show("Iterator:"+ iterator._model.VariableName+"\n Value:"+ iterator.VariableValue+ "\n Model Vlaue:"+iterator._model.VariableValue);
+                //      VariableModelToBeReset.VariableValue = iterator.VariableStartValue;
+                //  }
+                ////// MessageBox.Show("Iterator:"+ iterator._model.VariableName+"\n Value:"+ iterator.VariableValue+ "\n Model Vlaue:"+iterator._model.VariableValue);
             }
             RefreshVariableValuesInGUI(false, true, true);
             // Ebaa 18.06.2018
             // reenable buffer updates
-           // VariableUpdateDone(bufferUpdateLock);
+            // VariableUpdateDone(bufferUpdateLock);
         }
         List<List<VariableModel>> iterationPattern = new List<List<VariableModel>>();
         public void createIterationPattern()
@@ -935,8 +912,8 @@ namespace Controller.Variables
         //private bool shuffleIterations = true;
         //private bool pause = false;
         private int shuffleIterationsCounter = 0;
-       
-        
+
+
         /// <summary>
         /// Iterates the variables
         /// </summary>
@@ -978,8 +955,8 @@ namespace Controller.Variables
 
                 foreach (VariableController iterator in VariablesIterator)
                 {
-                  //  to be deleted
-                  //  VariableModel VariableModelToBeReset = _outputHandler.Model.Data.variablesModel.VariablesList.Find(x => x.VariableName == iterator._model.VariableName);
+                    //  to be deleted
+                    //  VariableModel VariableModelToBeReset = _outputHandler.Model.Data.variablesModel.VariablesList.Find(x => x.VariableName == iterator._model.VariableName);
                     // only increase variable if the one before had an overflow
                     if (lastVariableOverflowed)
                     {
@@ -989,24 +966,24 @@ namespace Controller.Variables
                             lastVariableOverflowed = true;
                             iterator.VariableValue = iterator.VariableStartValue;
                             //to be deleted
-                          //  VariableModelToBeReset.VariableValue = VariableModelToBeReset.VariableStartValue;
+                            //  VariableModelToBeReset.VariableValue = VariableModelToBeReset.VariableStartValue;
                             continue;
                         }
 
                         double nextValue = iterator.VariableValue + iterator.VariableStepValue;
                         //to be deleted
-                      //  nextValue = VariableModelToBeReset.VariableValue + VariableModelToBeReset.VariableStepValue;
+                        //  nextValue = VariableModelToBeReset.VariableValue + VariableModelToBeReset.VariableStepValue;
                         const double FLOATMARGIN = 1E-7;
                         if ((nextValue <= iterator.VariableEndValue + FLOATMARGIN && iterator.VariableStepValue > 0) ||
                             (nextValue >= iterator.VariableEndValue - FLOATMARGIN && iterator.VariableStepValue < 0))
                         {
                             lastVariableOverflowed = false;
                             iterator.VariableValue = nextValue;
-                          //  _outputHandler.Model.Data.variablesModel.VariablesList.ElementAt(0).VariableValue = nextValue;
+                            //  _outputHandler.Model.Data.variablesModel.VariablesList.ElementAt(0).VariableValue = nextValue;
                             //to be deleted
-                       //     VariableModelToBeReset.VariableValue = nextValue;
-                        //   MessageBox.Show("inside iterate method"+iterator.VariableValue.ToString() + "\n");
-                          //  MessageBox.Show( "inside iterate method variableModel: " + _rootModel.Data.variablesModel.VariablesList.ElementAt(0).VariableValue.ToString());
+                            //     VariableModelToBeReset.VariableValue = nextValue;
+                            //   MessageBox.Show("inside iterate method"+iterator.VariableValue.ToString() + "\n");
+                            //  MessageBox.Show( "inside iterate method variableModel: " + _rootModel.Data.variablesModel.VariablesList.ElementAt(0).VariableValue.ToString());
 
                         }
                         else
@@ -1043,7 +1020,7 @@ namespace Controller.Variables
             builder.SetModelVariableValues(_parentController.returnModel.Data, false);
             builder.AddGlobalVariablesToScope();
             builder.SetScript("pass");
-            HighPerformancePythonScriptExecutor executer = (HighPerformancePythonScriptExecutor) builder.Build();//One executer for all variables
+            HighPerformancePythonScriptExecutor executer = (HighPerformancePythonScriptExecutor)builder.Build();//One executer for all variables
 
             foreach (VariableController dynamicVariable in VariablesDynamic)
             {

--- a/Controller/Controller/Variables/VariablesController.cs
+++ b/Controller/Controller/Variables/VariablesController.cs
@@ -40,7 +40,7 @@ namespace Controller.Variables
         //ObservableCollections containing all Variables and only show specified Variables if needed.
         public ObservableCollection<VariableController> Variables = new ObservableCollection<VariableController>();
 
-        // ******************** variables ********************
+        // ******************** Variables ********************
         private const double FLOATMARGIN = 1E-7;
 
         /// <summary>
@@ -58,8 +58,6 @@ namespace Controller.Variables
 
         private List<List<VariableModel>> iterationPattern = new List<List<VariableModel>>();
 
-        //private bool shuffleIterations = true;
-        //private bool pause = false;
         private int shuffleIterationsCounter = 0;
 
         /// <summary>
@@ -67,7 +65,7 @@ namespace Controller.Variables
         /// </summary>
         private int staticVariablesPerGroupColumn;
 
-        // ******************** constructor ********************
+        // ******************** Constructor ********************
         /// <summary>
         /// Public constructor for the Variables Controller.
         /// </summary>
@@ -91,6 +89,7 @@ namespace Controller.Variables
             ReadOptions();
         }
 
+        // ******************** Delegates and Events ********************
         public delegate void LoseFocusOnIterators(object sender, EventArgs e);
 
         public delegate void VariablesListChangedEventHandler(object sender, VariablesChangedEventArgs e);
@@ -99,13 +98,16 @@ namespace Controller.Variables
 
         public event LoseFocusOnIterators LoseFocus;
 
+        public event PropertyChangedEventHandler PropertyChanged;
+
         public event EventHandler RefreshWindows;
 
         public event VariablesListChangedEventHandler VariablesListChanged;
 
-        //Events that occur when the Variables are changed (Values) or the order and Variable Types are changed (List).
+        // Events that occur when the Variables are changed (Values) or the order and Variable Types are changed (List).
         public event VariablesValueChangedEventHandler VariablesValueChanged;
 
+        // ******************** Properties ********************
         public ICommand AddDynamic { get; private set; }
 
         public ICommand AddIterator { get; private set; }
@@ -172,25 +174,6 @@ namespace Controller.Variables
                 OnPropertyChanged("StaticGroupHeight");
             }
         }
-
-        // ******************** events ********************
-
-        #region INotifyPropertyChanged Members
-
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        /// <summary>
-        /// Called when [property changed].
-        /// </summary>
-        /// <param name="propertyName">Name of the property.</param>
-        public void OnPropertyChanged(string propertyName)
-        {
-            if (PropertyChanged != null)
-                PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
-        }
-
-        #endregion INotifyPropertyChanged Members
-
         public ObservableCollection<VariableController> VariablesDynamic
         {
             get
@@ -276,6 +259,7 @@ namespace Controller.Variables
 
         private ICommand MoveVariableToNewGroupCommand { set; get; }
 
+        // ******************** Public Methods ********************
         /// <summary>
         /// Adds a dynamic variable
         /// </summary>
@@ -403,6 +387,14 @@ namespace Controller.Variables
             menuList.Add(item);
 
             return menuList;
+        }
+
+        /// <summary>
+        /// Requests the buffer to accept the current model which will be read to generate the output of future cycles.
+        /// </summary>
+        public void CopyToBuffer()
+        {
+            _parentController.CopyToBuffer();
         }
 
         public void countTotalNumberOfIterations()
@@ -594,7 +586,7 @@ namespace Controller.Variables
             //return null;
         }
 
-        // ******************** properties ********************
+
         public Root.RootController GetRootController()
         {
             return _parentController;
@@ -800,6 +792,16 @@ namespace Controller.Variables
         public void NotifyOptionsChanged()
         {
             ReadOptions();
+        }
+
+        /// <summary>
+        /// Called when [property changed].
+        /// </summary>
+        /// <param name="propertyName">Name of the property.</param>
+        public void OnPropertyChanged(string propertyName)
+        {
+            if (PropertyChanged != null)
+                PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
         }
 
         public void RefreshVariableValuesInGUI(bool refreshStatics, bool refreshIterators, bool refreshDynamics)
@@ -1014,11 +1016,10 @@ namespace Controller.Variables
             _parentController = parentController;
         }
 
-        // ******************** lock stuff ********************
+        // ******************** Private Methods ********************
         /// <summary>
         /// avoid inconsistency the data should not be copied to the buffer until all updates are done. In _variableUpdateLockObject the very first lock object is stored, all objects from sub updates are not stored. The updateVariablesListFromParent is prevented until the lock is released.
         /// </summary>
-        //private Object _variableUpdateLockObject = null;
         private void LockIterators(object sender, EventArgs e)
         {
             this.LoseFocus(null, null);
@@ -1070,50 +1071,5 @@ namespace Controller.Variables
             }
             System.Console.WriteLine("Unlocked iterators");
         }
-
-        /*public void UpdateSpecificVarialbesCollection(CustomElements.VariableType varType)
-        {
-            switch (varType)
-            {
-                case VariableType.VariableTypeStatic:
-                        if (PropertyChanged != null)
-                        {
-                            PropertyChanged(this, new PropertyChangedEventArgs("VariablesStatic"));
-                        }
-                        break;
-
-                case VariableType.VariableTypeIterator:
-                        if (PropertyChanged != null)
-                        {
-                            PropertyChanged(this, new PropertyChangedEventArgs("VariablesIterator"));
-                        }
-                        break;
-
-                case VariableType.VariableTypeDynamic:
-                        if (PropertyChanged != null)
-                        {
-                            PropertyChanged(this, new PropertyChangedEventArgs("VariablesDynamic"));
-                        }
-                        break;
-        }
-            //System.Console.Write("b\n");
-            if (VariablesListChanged != null)
-            {
-                VariablesListChanged(this, null);
-            }
-        }*/
-        /* refresh the gui */
-
-        #region IController Members
-
-        /// <summary>
-        /// Requests the buffer to accept the current model which will be read to generate the output of future cycles.
-        /// </summary>
-        public void CopyToBuffer()
-        {
-            _parentController.CopyToBuffer();
-        }
-
-        #endregion IController Members
     }
 }

--- a/Controller/Controller/Variables/VariablesController.cs
+++ b/Controller/Controller/Variables/VariablesController.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.ComponentModel;
-using System.Linq;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Input;
-using Buffer.Basic;
+﻿using Buffer.Basic;
 using Communication;
 using Communication.Commands;
 using Communication.Interfaces.Controller;
@@ -18,135 +10,111 @@ using Model.Root;
 using Model.Variables;
 using PythonUtils;
 using PythonUtils.ScriptExecution;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
 
 namespace Controller.Variables
 {
     public class VariablesChangedEventArgs : EventArgs
     {
-        public bool RefreshStatics { set; get; }
-        public bool RefreshIterators { set; get; }
         public bool RefreshDynamics { set; get; }
+        public bool RefreshIterators { set; get; }
+        public bool RefreshStatics { set; get; }
     }
+
     public class VariablesController : INotifyPropertyChanged, IWindowController, IController
     {
+        //The Variables Model containing all Variables.
+        public RootModel _rootModel;
+
+        public VariablesModel _variablesModel;
+
+        public int numberOfIterations;
+
+        //ObservableCollections containing all Variables and only show specified Variables if needed.
+        public ObservableCollection<VariableController> Variables = new ObservableCollection<VariableController>();
+
         // ******************** variables ********************
-        const double FLOATMARGIN = 1E-7;
+        private const double FLOATMARGIN = 1E-7;
 
         /// <summary>
         /// The height (in pixels) of a single variable in the variables window
         /// </summary>
         private const int VARIABLE_HEIGHT = 28;
+
+        private readonly OutputHandler _outputHandler;
+
+        private bool _iteratorsLocked = false;
+
+        private Root.RootController _parentController;
+
+        private Dictionary<int, bool> groupsExpandState;
+
+        private List<List<VariableModel>> iterationPattern = new List<List<VariableModel>>();
+
+        //private bool shuffleIterations = true;
+        //private bool pause = false;
+        private int shuffleIterationsCounter = 0;
+
         /// <summary>
         /// The maximum number of static variables per one column in a group
         /// </summary>
         private int staticVariablesPerGroupColumn;
 
+        // ******************** constructor ********************
         /// <summary>
-        /// Gets or sets the static variables per group column.
+        /// Public constructor for the Variables Controller.
         /// </summary>
-        /// <value>
-        /// The static variables per group column.
-        /// </value>
-        public int StaticVariablesPerGroupColumn
+        /// <param name="variablesModel">The variables model which is within the complete data model.</param>
+        public VariablesController(VariablesModel variablesModel, OutputHandler outputHandler, RootModel rootModel)
         {
-            get { return staticVariablesPerGroupColumn; }
-            set
-            {
-                staticVariablesPerGroupColumn = value;
-                OnPropertyChanged("StaticVariablesPerGroupColumn");
-                OnPropertyChanged("StaticGroupHeight");
-            }
+            _outputHandler = outputHandler;
+            SetNewRootModel(rootModel);
+            SetNewVariablesModel(variablesModel);
+            _outputHandler.LockIterators += LockIterators;
+            _outputHandler.UnlockIterators += UnlockIterators;
+            AddStatic = new RelayCommand(addStatic);
+            AddIterator = new RelayCommand(addIterator);
+            AddDynamic = new RelayCommand(addDynamic);
+            Evaluate = new RelayCommand(evaluate);
+            Iterate = new RelayCommand(iterate);
+            Check = new RelayCommand(CheckAllVariablesUsage);
+            StaticGroupSelect = new RelayCommand(DoStaticGroupSelect);
+            MoveVariableToNewGroupCommand = new RelayCommand(MoveVariableToNewGroup);
+
+            ReadOptions();
         }
 
-        /// <summary>
-        /// Gets the maximum height of a static variables group measured in pixels
-        /// </summary>
-        /// <value>
-        /// The height of the static group.
-        /// </value>
-        public double StaticGroupHeight
-        {
-            get
-            {
-                return (double)VARIABLE_HEIGHT * StaticVariablesPerGroupColumn;
-            }
-        }
+        public delegate void LoseFocusOnIterators(object sender, EventArgs e);
 
-        private Root.RootController _parentController;
+        public delegate void VariablesListChangedEventHandler(object sender, VariablesChangedEventArgs e);
 
-        //The Variables Model containing all Variables.
-        public RootModel _rootModel;
-        public VariablesModel _variablesModel;
-        private readonly OutputHandler _outputHandler;
+        public delegate void VariablesValueChangedEventHandler(object sender, VariableController changedVar);
 
-        public int numberOfIterations;
-
-        private Dictionary<int, bool> groupsExpandState;
-
-
-        // ******************** events ********************
-        #region INotifyPropertyChanged Members
-
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        /// <summary>
-        /// Called when [property changed].
-        /// </summary>
-        /// <param name="propertyName">Name of the property.</param>
-        public void OnPropertyChanged(string propertyName)
-        {
-            if (PropertyChanged != null)
-                PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
-        }
-
-        #endregion
-
-
-        //Events that occur when the Variables are changed (Values) or the order and Variable Types are changed (List).
-        public event VariablesValueChangedEventHandler VariablesValueChanged;
-        public event VariablesListChangedEventHandler VariablesListChanged;
         public event LoseFocusOnIterators LoseFocus;
 
         public event EventHandler RefreshWindows;
 
-        public void DoRefreshWindows()
-        {
-            if (RefreshWindows != null)
-            {
-                RefreshWindows(this, new EventArgs());
-            }
-        }
+        public event VariablesListChangedEventHandler VariablesListChanged;
 
-        public delegate void VariablesListChangedEventHandler(object sender, VariablesChangedEventArgs e);
-        public delegate void VariablesValueChangedEventHandler(object sender, VariableController changedVar);
+        //Events that occur when the Variables are changed (Values) or the order and Variable Types are changed (List).
+        public event VariablesValueChangedEventHandler VariablesValueChanged;
 
-        public delegate void LoseFocusOnIterators(object sender, EventArgs e);
+        public ICommand AddDynamic { get; private set; }
+
+        public ICommand AddIterator { get; private set; }
+
+        public ICommand AddStatic { get; private set; }
 
         public ICommand Check { get; private set; }
-        public ICommand Iterate { get; private set; }
+
         public ICommand Evaluate { get; private set; }
-        public ICommand AddStatic { get; private set; }
-        public ICommand AddIterator { get; private set; }
-        public ICommand AddDynamic { get; private set; }
-        public ICommand StaticGroupSelect { get; set; }
-        private ICommand MoveVariableToNewGroupCommand { set; get; }
-
-
-        // ******************** properties ********************
-
-        public ObservableCollection<ShowableWindow> WindowsList
-        {
-            get
-            {
-                return MainWindowController.WindowsList;
-            }
-        }
-
-
-        public Root.RootController GetRootController()
-        {
-            return _parentController;
-        }
 
         public Dictionary<int, string> GroupNames
         {
@@ -170,69 +138,94 @@ namespace Controller.Variables
             }
         }
 
-        public List<MenuItem> constructStaticGroups(VariableController variable)
-        {
-            List<MenuItem> menuList = new List<MenuItem>();
-            MenuItem item;
-            List<KeyValuePair<int, string>> dictionaryAsList = new List<KeyValuePair<int, string>>(GroupNames);
-            dictionaryAsList.Sort(
-                (item1, item2) =>
-                {
-                    return item1.Value.CompareTo(item2.Value);
-                }
-            );
-
-
-            foreach (KeyValuePair<int, string> group in dictionaryAsList)
-            {
-                item = new MenuItem();
-                item.Header = group.Value;
-                item.Command = StaticGroupSelect;
-                item.CommandParameter = new Tuple<VariableController, int>(variable, group.Key);
-                menuList.Add(item);
-            }
-
-
-            item = new MenuItem();
-            item.Header = "Create New Group ...";
-            item.Command = MoveVariableToNewGroupCommand;
-            item.CommandParameter = variable;
-            item.Background = SystemColors.HighlightBrush;
-            item.Foreground = SystemColors.HighlightTextBrush;
-            menuList.Add(item);
-
-            return menuList;
-        }
+        public ICommand Iterate { get; private set; }
 
         /// <summary>
-        /// Moves the variable to a new group with a default name.
+        /// Gets the maximum height of a static variables group measured in pixels
         /// </summary>
-        /// <param name="parameter">The <see cref=" VariableController"/> of the corresponding variable.</param>
-        private void MoveVariableToNewGroup(object parameter)
+        /// <value>
+        /// The height of the static group.
+        /// </value>
+        public double StaticGroupHeight
         {
-            VariableController variable = (VariableController)parameter;
-            int groupKey = -1;
-
-            foreach (int key in GroupNames.Keys)
-                if (key > groupKey)
-                    groupKey = key;
-
-            groupKey++;
-            GroupNames.Add(groupKey, "New Group " + groupKey);
-            GroupsExpandState.Add(groupKey, true);
-            variable.GroupIndex = groupKey;
-            updateStatics();
+            get
+            {
+                return (double)VARIABLE_HEIGHT * StaticVariablesPerGroupColumn;
+            }
         }
 
-        public void DoStaticGroupSelect(object parameter)
+        public ICommand StaticGroupSelect { get; set; }
+
+        /// <summary>
+        /// Gets or sets the static variables per group column.
+        /// </summary>
+        /// <value>
+        /// The static variables per group column.
+        /// </value>
+        public int StaticVariablesPerGroupColumn
         {
-            Tuple<VariableController, int> realPar = parameter as Tuple<VariableController, int>;
-            realPar.Item1.GroupIndex = realPar.Item2;
-            updateStatics();
+            get { return staticVariablesPerGroupColumn; }
+            set
+            {
+                staticVariablesPerGroupColumn = value;
+                OnPropertyChanged("StaticVariablesPerGroupColumn");
+                OnPropertyChanged("StaticGroupHeight");
+            }
         }
 
-        //ObservableCollections containing all Variables and only show specified Variables if needed.
-        public ObservableCollection<VariableController> Variables = new ObservableCollection<VariableController>();
+        // ******************** events ********************
+
+        #region INotifyPropertyChanged Members
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary>
+        /// Called when [property changed].
+        /// </summary>
+        /// <param name="propertyName">Name of the property.</param>
+        public void OnPropertyChanged(string propertyName)
+        {
+            if (PropertyChanged != null)
+                PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        #endregion INotifyPropertyChanged Members
+
+        public ObservableCollection<VariableController> VariablesDynamic
+        {
+            get
+            {
+                return new ObservableCollection<VariableController>(from varCtrl in
+                                                                        new
+                                                                        ObservableCollection
+                                                                            <VariableController>(
+                                                                        Variables.Where(
+                                                                            w =>
+                                                                            w.TypeOfVariable.Equals(
+                                                                                VariableType.
+                                                                                    VariableTypeDynamic)))
+                                                                    orderby varCtrl.getModelIndex ascending
+                                                                    select varCtrl);
+            }
+        }
+
+        public ObservableCollection<VariableController> VariablesIterator
+        {
+            get
+            {
+                return new ObservableCollection<VariableController>(from varCtrl in
+                                                                        new
+                                                                        ObservableCollection
+                                                                            <VariableController>(
+                                                                        Variables.Where(
+                                                                            w =>
+                                                                            w.TypeOfVariable.Equals(
+                                                                                VariableType.
+                                                                                    VariableTypeIterator)))
+                                                                    orderby varCtrl.getModelIndex ascending
+                                                                    select varCtrl);
+            }
+        }
 
         /// <summary>
         /// Gets a sorted collection of the controllers of static variables
@@ -240,7 +233,7 @@ namespace Controller.Variables
         /// <value>
         /// The static variables' controllers
         /// </value>
-        /// <remarks>The collection is sorted based on the group name, then on the fact whether the variable is a 
+        /// <remarks>The collection is sorted based on the group name, then on the fact whether the variable is a
         /// group header or a regular variable, and finally based on the variable name.</remarks>
         public ObservableCollection<VariableController> VariablesStatic
         {
@@ -272,486 +265,47 @@ namespace Controller.Variables
                                                                  select tempVarController);
             }
         }
-        public ObservableCollection<VariableController> VariablesIterator
+
+        public ObservableCollection<ShowableWindow> WindowsList
         {
             get
             {
-                return new ObservableCollection<VariableController>(from varCtrl in
-                                                                        new
-                                                                        ObservableCollection
-                                                                            <VariableController>(
-                                                                        Variables.Where(
-                                                                            w =>
-                                                                            w.TypeOfVariable.Equals(
-                                                                                VariableType.
-                                                                                    VariableTypeIterator)))
-                                                                    orderby varCtrl.getModelIndex ascending
-                                                                    select varCtrl);
+                return MainWindowController.WindowsList;
             }
         }
-        public ObservableCollection<VariableController> VariablesDynamic
-        {
-            get
-            {
-                return new ObservableCollection<VariableController>(from varCtrl in
-                                                                        new
-                                                                        ObservableCollection
-                                                                            <VariableController>(
-                                                                        Variables.Where(
-                                                                            w =>
-                                                                            w.TypeOfVariable.Equals(
-                                                                                VariableType.
-                                                                                    VariableTypeDynamic)))
-                                                                    orderby varCtrl.getModelIndex ascending
-                                                                    select varCtrl);
-            }
-        }
+
+        private ICommand MoveVariableToNewGroupCommand { set; get; }
 
         /// <summary>
-        /// Returns a variable by its name.
+        /// Adds a dynamic variable
         /// </summary>
-        /// <param name="name">Name of the variable to find</param>
-        /// <returns>the variable specified by name or null if it cannot be found</returns>
-        public VariableController GetByName(String name)
+        /// <param name="parameter">unused</param>
+        public void addDynamic(object parameter)
         {
-            foreach (VariableController variable in Variables)
-            {
-                if (name.Equals(variable.VariableName))
-                {
-                    return variable;
-                }
-            }
-            throw new Exception("Variable not found! Name: " + name);
-            //return null;
-        }
+            VariableModel variableModel = _variablesModel.addVariable();
 
-        // ******************** lock stuff ********************
-        /// <summary>
-        /// avoid inconsistency the data should not be copied to the buffer until all updates are done. In _variableUpdateLockObject the very first lock object is stored, all objects from sub updates are not stored. The updateVariablesListFromParent is prevented until the lock is released. 
-        /// </summary>
-        //private Object _variableUpdateLockObject = null;
-
-        /// <summary>
-        /// disables the CopyToBuffer function until a VariablesUpdateDone with the object _variableUpdateLockObject is called 
-        /// </summary>
-        public Object VariableUpdateStart()
-        {
-            //var lockObject = new object();
-            //if (_variableUpdateLockObject == null)//Only who has the first lock wins!!
-            //{
-            //    _variableUpdateLockObject = lockObject;
-            //}
-            //_parentController.DisableCopyToBuffer();
-            //return lockObject;
-
-            return _parentController.BulkUpdateStart();
-        }
-
-        /// <summary>
-        /// re-enables and triggers the CopyToBuffer function if the object in the argument matches the _variableUpdateLockObject
-        /// </summary>
-        /// <param name="lockObject">lock/unlock object</param>
-        public bool VariableUpdateDone(Object lockObject)
-        {
-            //if (_variableUpdateLockObject == lockObject)
-            //{
-            //    _variableUpdateLockObject = null;
-            //    _parentController.EnableCopyToBufferAndCopyChanges();
-            //}
-
-            return _parentController.BulkUpdateEnd(lockObject);
-        }
-
-        void LockIterators(object sender, EventArgs e)
-        {
-            this.LoseFocus(null, null);
-
-            // ResetIteratorValues();
-            evaluate(null);
-            _iteratorsLocked = true;
-            System.Console.WriteLine("Locked iterators");
-            foreach (VariableController iterator in VariablesIterator)
-            {
-                iterator.VariableLocked = true;
-            }
-        }
-
-        void UnlockIterators(object sender, EventArgs e)
-        {
-            _iteratorsLocked = false;
-            foreach (VariableController iterator in VariablesIterator)
-            {
-                iterator.VariableLocked = false;
-            }
-            System.Console.WriteLine("Unlocked iterators");
-        }
-
-        private bool _iteratorsLocked = false;
-
-        public bool IsIteratorsLocked()
-        {
-            return _iteratorsLocked;
-        }
-
-
-        // ******************** constructor ********************
-        /// <summary>
-        /// Public constructor for the Variables Controller.
-        /// </summary>
-        /// <param name="variablesModel">The variables model which is within the complete data model.</param>
-        public VariablesController(VariablesModel variablesModel, OutputHandler outputHandler, RootModel rootModel)
-        {
-            _outputHandler = outputHandler;
-            SetNewRootModel(rootModel);
-            SetNewVariablesModel(variablesModel);
-            _outputHandler.LockIterators += LockIterators;
-            _outputHandler.UnlockIterators += UnlockIterators;
-            AddStatic = new RelayCommand(addStatic);
-            AddIterator = new RelayCommand(addIterator);
-            AddDynamic = new RelayCommand(addDynamic);
-            Evaluate = new RelayCommand(evaluate);
-            Iterate = new RelayCommand(iterate);
-            Check = new RelayCommand(CheckAllVariablesUsage);
-            StaticGroupSelect = new RelayCommand(DoStaticGroupSelect);
-            MoveVariableToNewGroupCommand = new RelayCommand(MoveVariableToNewGroup);
-
-            ReadOptions();
-        }
-
-
-        public void countTotalNumberOfIterations()
-        {
-            int count = 1;
-            foreach (var variable in VariablesIterator)
-            {
-                double currentVal = variable.VariableStartValue;
-                int localCount = 1;
-                while (true)
-                {
-                    currentVal += variable.VariableStepValue;
-                    if (((currentVal > variable.VariableEndValue + FLOATMARGIN && variable.VariableStepValue >= 0) || (currentVal < variable.VariableEndValue - FLOATMARGIN && variable.VariableStepValue < 0)) || variable.VariableStepValue == 0)
-                    {
-                        break;
-                    }
-                    localCount++;
-                }
-                count = count * localCount;
-            }
-            numberOfIterations = count;
-            _outputHandler.NumberOfIterations = count;
-
-        }
-
-        /// <summary>
-        /// Sets a new model for the variables
-        /// </summary>
-        /// <param name="variablesModel">the model which will replace the old one</param>
-        public void SetNewVariablesModel(VariablesModel variablesModel)
-        {
-            this._variablesModel = variablesModel;
-            Variables.Clear();
-            foreach (VariableModel variable in variablesModel.VariablesList)
-            {
-                Variables.Add(new VariableController(variable, this));
-            }
+            VariableController variable = new VariableController(variableModel, this);
+            variable.TypeOfVariable = VariableType.VariableTypeDynamic;
+            Variables.Add(variable);
+            //UpdateSpecificVarialbesCollection(VariableType.VariableTypeDynamic);
             UpdateVariablesList();
+        }
+
+        /// <summary>
+        /// Adds an iterator variable
+        /// </summary>
+        /// <param name="parameter">unused</param>
+        public void addIterator(object parameter)
+        {
+            VariableModel variableModel = _variablesModel.addVariable();
+
+            VariableController variable = new VariableController(variableModel, this);
+            variable.TypeOfVariable = VariableType.VariableTypeIterator;
+            Variables.Add(variable);
+            //UpdateSpecificVarialbesCollection(VariableType.VariableTypeIterator);
+            UpdateVariablesList();
+
             countTotalNumberOfIterations();
-        }
-
-        /// <summary>
-        /// Sets a new RootModel for the variables
-        /// </summary>
-        /// <param name="variablesModel">the model which will replace the old one</param>
-        public void SetNewRootModel(RootModel rootModel)
-        {
-            this._rootModel = rootModel;
-            groupsExpandState = null;
-        }
-
-
-
-        /// <summary>
-        /// A function that will be called if the Buffer wants to iterate(and evaluate) the Variables
-        /// </summary>
-        /// <param name="sender">unused</param>
-        /// <param name="e">unused</param>
-        public void IterateVariablesFromBuffer(object sender, EventArgs e)
-        {
-            iterate(null);
-        }
-
-        /// <summary>
-        /// A function that will be called if the Buffer wants to evaluate the Variables
-        /// </summary>
-        /// <param name="sender">unused</param>
-        /// <param name="e">unused</param>
-        public void EvaluateVariablesFromBuffer(object sender, EventArgs e)
-        {
-            evaluate(null);
-        }
-
-        public void ResetIteratorValuesFromBuffer(object sender, EventArgs e)
-        {
-            ResetIteratorValues();
-            evaluate(null);
-        }
-
-        public void moveUp(VariableController variableController)
-        {
-            if (variableController.TypeOfVariable == VariableType.VariableTypeIterator
-                || variableController.TypeOfVariable == VariableType.VariableTypeDynamic)
-            {
-                int currentModelIndex = _variablesModel.VariablesList.IndexOf(variableController._model);
-
-                if (currentModelIndex > 0)
-                {
-                    // find the variable to swap with   
-                    VariableModel previousVariable = null;
-                    int previousModelIndex = currentModelIndex;
-
-                    do
-                    {
-                        --previousModelIndex;
-                        previousVariable = _variablesModel.VariablesList[previousModelIndex];
-                    }
-                    while (!previousVariable.TypeOfVariable.Equals(variableController.TypeOfVariable) && previousModelIndex > 0);
-
-                    // if we managed to find a suitable step, swap it with the current one
-                    if (previousModelIndex > 0)
-                    {
-                        VariableModel currentVariable = _variablesModel.VariablesList[currentModelIndex];
-                        _variablesModel.VariablesList[currentModelIndex] = previousVariable;
-                        _variablesModel.VariablesList[previousModelIndex] = currentVariable;
-                        updatIterators();
-                        updateDynamics();
-                        countTotalNumberOfIterations();
-                    }
-                }
-            }
-            else if (variableController.TypeOfVariable == VariableType.VariableTypeStatic)
-            {
-                if (variableController.GroupIndex > 0)
-                {
-                    variableController.GroupIndex--;
-                    updateStatics();
-                }
-            }
-        }
-
-        public void moveDown(VariableController variableController)
-        {
-            if (variableController.TypeOfVariable == VariableType.VariableTypeIterator
-                || variableController.TypeOfVariable == VariableType.VariableTypeDynamic)
-            {
-                int currentModelIndex = _variablesModel.VariablesList.IndexOf(variableController._model);
-
-                if (currentModelIndex < _variablesModel.VariablesList.Count - 1)
-                {
-                    // find the variable to swap with   
-                    VariableModel nextVariable = null;
-                    int nextModelIndex = currentModelIndex;
-
-                    do
-                    {
-                        ++nextModelIndex;
-                        nextVariable = _variablesModel.VariablesList[nextModelIndex];
-                    }
-                    while (!nextVariable.TypeOfVariable.Equals(variableController.TypeOfVariable)
-                        && nextModelIndex < _variablesModel.VariablesList.Count - 1);
-
-                    // if we managed to find a suitable step, swap it with the current one
-                    if (nextModelIndex < _variablesModel.VariablesList.Count - 1)
-                    {
-                        VariableModel currentVariable = _variablesModel.VariablesList[currentModelIndex];
-                        _variablesModel.VariablesList[currentModelIndex] = nextVariable;
-                        _variablesModel.VariablesList[nextModelIndex] = currentVariable;
-                        updatIterators();
-                        updateDynamics();
-                        countTotalNumberOfIterations();
-                    }
-                }
-            }
-            if (variableController.TypeOfVariable == VariableType.VariableTypeStatic)
-            {
-                variableController.GroupIndex++;
-                updateStatics();
-            }
-        }
-
-        /*public void UpdateSpecificVarialbesCollection(CustomElements.VariableType varType)
-        {
-            switch (varType)
-            {
-                case VariableType.VariableTypeStatic: 
-                        if (PropertyChanged != null)
-                        {
-                            PropertyChanged(this, new PropertyChangedEventArgs("VariablesStatic"));
-                        }
-                        break;
-                case VariableType.VariableTypeIterator:
-                        if (PropertyChanged != null)
-                        {
-                            PropertyChanged(this, new PropertyChangedEventArgs("VariablesIterator"));
-                        }
-                        break;
-                case VariableType.VariableTypeDynamic:
-                        if (PropertyChanged != null)
-                        {
-                            PropertyChanged(this, new PropertyChangedEventArgs("VariablesDynamic"));
-                        }
-                        break;
-        }
-            //System.Console.Write("b\n");
-            if (VariablesListChanged != null)
-            {
-                VariablesListChanged(this, null);
-            }
-        }*/
-
-        /// <summary>
-        /// This function gets called when the Lists of Variables are changed.
-        /// </summary>
-        public void UpdateVariablesList()//This function deletes the focus of an input field
-        {
-            if (PropertyChanged != null)
-            {
-                PropertyChanged(this, new PropertyChangedEventArgs("VariablesStatic"));
-                PropertyChanged(this, new PropertyChangedEventArgs("VariablesIterator"));
-                PropertyChanged(this, new PropertyChangedEventArgs("VariablesDynamic"));
-            }
-
-            VariablesListChanged?.Invoke(this, new VariablesChangedEventArgs() { RefreshStatics = true, RefreshIterators = true, RefreshDynamics = true });
-        }
-
-        public void UpdateVariablesListNoValues()//This function deletes the focus of an input field
-        {
-            if (PropertyChanged != null)
-            {
-                PropertyChanged(this, new PropertyChangedEventArgs("VariablesStatic"));
-                PropertyChanged(this, new PropertyChangedEventArgs("VariablesIterator"));
-                PropertyChanged(this, new PropertyChangedEventArgs("VariablesDynamic"));
-            }
-        }
-
-        public void updateStatics()
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("VariablesStatic"));
-        }
-        public void updatIterators()
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("VariablesIterator"));
-        }
-        public void updateDynamics()
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("VariablesDynamic"));
-        }
-
-
-
-        /* refresh the gui */
-        public void RefreshVariableValuesInGUI(bool refreshStatics, bool refreshIterators, bool refreshDynamics)
-        {
-            VariablesListChanged?.Invoke(this, new VariablesChangedEventArgs() { RefreshDynamics = refreshDynamics, RefreshIterators = refreshIterators, RefreshStatics = refreshStatics });
-        }
-
-        public void DoVariablesValueChanged(VariableController variable)
-        {
-            if (VariablesValueChanged != null)
-            {
-                VariablesValueChanged(this, variable);
-            }
-            _parentController.CopyToBuffer();
-        }
-
-        public void DoVariablesValueChangedByName(string name)
-        {
-            foreach (VariableController var in Variables)
-            {
-                if (var.VariableName == name)
-                {
-                    if (PropertyChanged != null)
-                    {
-                        PropertyChanged(var, new PropertyChangedEventArgs("VariableValue"));
-                    }
-                    if (VariablesValueChanged != null)
-                    {
-                        VariablesValueChanged(this, var);
-                    }
-                    _parentController.CopyToBuffer();
-                }
-            }
-        }
-
-        public void RemoveVariable(VariableController variable)
-        {
-            this.CheckAllVariablesUsage(null);
-
-            if (variable.Used)
-            {
-                MessageBoxResult result = MessageBox.Show(String.Format("This Variable is used in \n{0}, you cannot delete it!", variable.UsagesAsString));
-            }
-            else
-            {
-                MessageBoxResult result = MessageBox.Show("Do you really want to delete this Variable?\n" + variable.VariableName, "Confirmation", MessageBoxButton.YesNo, MessageBoxImage.Question);
-                if (result == MessageBoxResult.Yes)
-                {
-                    VariableModel localModel = variable._model;
-                    Variables.Remove(variable);
-                    _variablesModel.deleteVariable(localModel);
-                    UpdateVariablesList();
-                }
-
-            }
-        }
-
-        public void RemoveGroup(int groupKey)
-        {
-            if (GetVariablesOfGroup(groupKey).Count > 0)
-            {
-                MessageBox.Show("The group you are trying to remove contains variables. Please ensure that the group is empty before trying to remove it.",
-                    "Unable to Remove Group", MessageBoxButton.OK, MessageBoxImage.Error);
-            }
-            else
-            {
-                GroupNames.Remove(groupKey);
-                GroupsExpandState.Remove(groupKey);
-                updateStatics();
-            }
-        }
-
-        public void RenameGroup(int groupKey, string groupName)
-        {
-            bool isNameUsed = false;
-            foreach (string name in GroupNames.Values)
-            {
-                if (groupName.Equals(name))
-                {
-                    isNameUsed = true;
-                    break;
-                }
-            }
-
-            if (isNameUsed)
-                MessageBox.Show("This group name is already in use please choose another one!", "Cannot Rename Group", MessageBoxButton.OK, MessageBoxImage.Error);
-            else
-            {
-                GroupNames[groupKey] = groupName;
-                updateStatics();
-            }
-        }
-
-        public ObservableCollection<VariableController> GetVariablesOfGroup(int groupKey)
-        {
-            ObservableCollection<VariableController> result = new ObservableCollection<VariableController>();
-
-            foreach (VariableController vController in Variables)
-            {
-                if (vController.TypeOfVariable == VariableType.VariableTypeStatic && vController.GroupIndex == groupKey)
-                    result.Add(vController);
-
-            }
-
-            return result;
         }
 
         /// <summary>
@@ -777,66 +331,102 @@ namespace Controller.Variables
         }
 
         /// <summary>
-        /// Adds an iterator variable
+        /// Checks the usage of all variables
         /// </summary>
-        /// <param name="parameter">unused</param>
-        public void addIterator(object parameter)
+        /// <param name="parameter">null</param>
+        public void CheckAllVariablesUsage(object parameter)
         {
-            VariableModel variableModel = _variablesModel.addVariable();
+            VariableUsageChecker checker = new VariableUsageChecker(_rootModel);
 
-            VariableController variable = new VariableController(variableModel, this);
-            variable.TypeOfVariable = VariableType.VariableTypeIterator;
-            Variables.Add(variable);
-            //UpdateSpecificVarialbesCollection(VariableType.VariableTypeIterator);
-            UpdateVariablesList();
-
-            countTotalNumberOfIterations();
-        }
-
-        /// <summary>
-        /// Adds a dynamic variable
-        /// </summary>
-        /// <param name="parameter">unused</param>
-        public void addDynamic(object parameter)
-        {
-            VariableModel variableModel = _variablesModel.addVariable();
-
-            VariableController variable = new VariableController(variableModel, this);
-            variable.TypeOfVariable = VariableType.VariableTypeDynamic;
-            Variables.Add(variable);
-            //UpdateSpecificVarialbesCollection(VariableType.VariableTypeDynamic);
-            UpdateVariablesList();
-        }
-
-
-        public void ResetIteratorValues()
-        {
-            // Ebaa 18.06.2018
-            // prevent inconsistencies and multiple updates on the buffer
-            // Object bufferUpdateLock = VariableUpdateStart();
-            foreach (VariableController iterator in VariablesIterator)
+            foreach (VariableController variable in Variables)
             {
+                variable.ClearUsages();
+                string currentUsage = "";
 
-                iterator.VariableValue = iterator.VariableStartValue;
+                foreach (VariableUsage usage in checker.GetUsagesOfVariable(variable.VariableName))
+                {
+                    switch (usage.UsageType)
+                    {
+                        case VariableUsageType.CalibrationScript:
+                            currentUsage = String.Format("Calibration Script at ({0})", usage.ScriptLocation.GetLocationAsString());
+                            break;
 
-                // //test 11.06
-                // VariableModel VariableModelToBeReset = _outputHandler.Model.Data.variablesModel.VariablesList.Find(x => x.VariableName == iterator._model.VariableName);
+                        case VariableUsageType.Duration:
+                            currentUsage = String.Format("Step Duration at ({0})", usage.ScriptLocation.GetLocationAsString());
+                            break;
 
+                        case VariableUsageType.Value:
+                            currentUsage = String.Format("Step Value at ({0})", usage.ScriptLocation.GetLocationAsString());
+                            break;
 
-                ////test 11.06
-                // if (VariableModelToBeReset != null)
-                //  {
+                        case VariableUsageType.DynamicVariable:
+                            currentUsage = String.Format("Dynamic Variable at ({0})", usage.ScriptLocation.GetLocationAsString());
+                            break;
 
-                //      VariableModelToBeReset.VariableValue = iterator.VariableStartValue;
-                //  }
-                ////// MessageBox.Show("Iterator:"+ iterator._model.VariableName+"\n Value:"+ iterator.VariableValue+ "\n Model Vlaue:"+iterator._model.VariableValue);
+                        case VariableUsageType.PythonStep:
+                            currentUsage = String.Format("Python Step at ({0})", usage.ScriptLocation.GetLocationAsString());
+                            break;
+                    }
+
+                    variable.AddUsage(currentUsage);
+                }
             }
-            RefreshVariableValuesInGUI(false, true, true);
-            // Ebaa 18.06.2018
-            // reenable buffer updates
-            // VariableUpdateDone(bufferUpdateLock);
         }
-        List<List<VariableModel>> iterationPattern = new List<List<VariableModel>>();
+
+        public List<MenuItem> constructStaticGroups(VariableController variable)
+        {
+            List<MenuItem> menuList = new List<MenuItem>();
+            MenuItem item;
+            List<KeyValuePair<int, string>> dictionaryAsList = new List<KeyValuePair<int, string>>(GroupNames);
+            dictionaryAsList.Sort(
+                (item1, item2) =>
+                {
+                    return item1.Value.CompareTo(item2.Value);
+                }
+            );
+
+            foreach (KeyValuePair<int, string> group in dictionaryAsList)
+            {
+                item = new MenuItem();
+                item.Header = group.Value;
+                item.Command = StaticGroupSelect;
+                item.CommandParameter = new Tuple<VariableController, int>(variable, group.Key);
+                menuList.Add(item);
+            }
+
+            item = new MenuItem();
+            item.Header = "Create New Group ...";
+            item.Command = MoveVariableToNewGroupCommand;
+            item.CommandParameter = variable;
+            item.Background = SystemColors.HighlightBrush;
+            item.Foreground = SystemColors.HighlightTextBrush;
+            menuList.Add(item);
+
+            return menuList;
+        }
+
+        public void countTotalNumberOfIterations()
+        {
+            int count = 1;
+            foreach (var variable in VariablesIterator)
+            {
+                double currentVal = variable.VariableStartValue;
+                int localCount = 1;
+                while (true)
+                {
+                    currentVal += variable.VariableStepValue;
+                    if (((currentVal > variable.VariableEndValue + FLOATMARGIN && variable.VariableStepValue >= 0) || (currentVal < variable.VariableEndValue - FLOATMARGIN && variable.VariableStepValue < 0)) || variable.VariableStepValue == 0)
+                    {
+                        break;
+                    }
+                    localCount++;
+                }
+                count = count * localCount;
+            }
+            numberOfIterations = count;
+            _outputHandler.NumberOfIterations = count;
+        }
+
         public void createIterationPattern()
         {
             List<VariableModel> localIterators = new List<VariableModel>();
@@ -847,19 +437,16 @@ namespace Controller.Variables
                 localIterators.Add(ctrl._model.DeepClone());
             }
 
-
             int ctr = 0;
             bool lastVariableOverflowed = false;
             while (!lastVariableOverflowed)
             {
                 List<VariableModel> toAddIterators = new List<VariableModel>();
 
-
                 foreach (VariableModel ctrl in localIterators)
                 {
                     toAddIterators.Add(ctrl.DeepClone());
                 }
-
 
                 iterationPattern.Add(new List<VariableModel>(new List<VariableModel>(toAddIterators)));
                 ctr++;
@@ -891,114 +478,47 @@ namespace Controller.Variables
                             iterator.VariableValue = iterator.VariableStartValue;
                         }
                     }
-
                 }
             }
             iterationPattern = Shuffle(iterationPattern);
             System.Console.Write("Everything should be saved into localIterators and localDynamics\n");
-
         }
 
-        public List<TValue> Shuffle<TValue>(
-           List<TValue> source)
+        public void DoRefreshWindows()
         {
-            Random r = new Random();
-            return source.OrderBy(x => r.Next())
-               .ToList();
+            if (RefreshWindows != null)
+            {
+                RefreshWindows(this, new EventArgs());
+            }
         }
 
-        //private bool shuffleIterations = true;
-        //private bool pause = false;
-        private int shuffleIterationsCounter = 0;
-
-
-        /// <summary>
-        /// Iterates the variables
-        /// </summary>
-        /// <param name="parameter">null</param>
-        public void iterate(object parameter)
+        public void DoStaticGroupSelect(object parameter)
         {
+            Tuple<VariableController, int> realPar = parameter as Tuple<VariableController, int>;
+            realPar.Item1.GroupIndex = realPar.Item2;
+            updateStatics();
+        }
 
-            // prevent inconsistencies and multiple updates on the buffer
-            Object bufferUpdateLock = VariableUpdateStart();
-
-            //createIterationPattern();
-            if (!_outputHandler.shuffleIterations)
+        public void DoVariablesValueChanged(VariableController variable)
+        {
+            if (VariablesValueChanged != null)
             {
-                shuffleIterationsCounter = 0;
+                VariablesValueChanged(this, variable);
             }
-            if (shuffleIterationsCounter == 0 && _outputHandler.shuffleIterations)
-            {
-                createIterationPattern();
-            }
+            _parentController.CopyToBuffer();
+        }
 
-
-            if (_outputHandler.shuffleIterations)
+        public void DoVariablesValueChangedByName(string name)
+        {
+            foreach (VariableController var in Variables)
             {
-                if (shuffleIterationsCounter >= iterationPattern.Count)
+                if (var.VariableName == name)
                 {
-                    shuffleIterationsCounter = 0;
+                    PropertyChanged?.Invoke(var, new PropertyChangedEventArgs("VariableValue"));
+                    VariablesValueChanged?.Invoke(this, var);
+                    _parentController.CopyToBuffer();
                 }
-                for (int i = 0; i < VariablesIterator.Count; i++)
-                {
-                    VariablesIterator[i].VariableValue = iterationPattern[shuffleIterationsCounter][i].VariableValue;
-                }
-                shuffleIterationsCounter++;
             }
-
-            if (!_outputHandler.shuffleIterations)
-            {
-                bool lastVariableOverflowed = true;
-
-
-                foreach (VariableController iterator in VariablesIterator)
-                {
-                    //  to be deleted
-                    //  VariableModel VariableModelToBeReset = _outputHandler.Model.Data.variablesModel.VariablesList.Find(x => x.VariableName == iterator._model.VariableName);
-                    // only increase variable if the one before had an overflow
-                    if (lastVariableOverflowed)
-                    {
-                        // first CheckAllVariablesUsage whether is this variable is not changing at all
-                        if (iterator.VariableStepValue == 0)
-                        {
-                            lastVariableOverflowed = true;
-                            iterator.VariableValue = iterator.VariableStartValue;
-                            //to be deleted
-                            //  VariableModelToBeReset.VariableValue = VariableModelToBeReset.VariableStartValue;
-                            continue;
-                        }
-
-                        double nextValue = iterator.VariableValue + iterator.VariableStepValue;
-                        //to be deleted
-                        //  nextValue = VariableModelToBeReset.VariableValue + VariableModelToBeReset.VariableStepValue;
-                        const double FLOATMARGIN = 1E-7;
-                        if ((nextValue <= iterator.VariableEndValue + FLOATMARGIN && iterator.VariableStepValue > 0) ||
-                            (nextValue >= iterator.VariableEndValue - FLOATMARGIN && iterator.VariableStepValue < 0))
-                        {
-                            lastVariableOverflowed = false;
-                            iterator.VariableValue = nextValue;
-                            //  _outputHandler.Model.Data.variablesModel.VariablesList.ElementAt(0).VariableValue = nextValue;
-                            //to be deleted
-                            //     VariableModelToBeReset.VariableValue = nextValue;
-                            //   MessageBox.Show("inside iterate method"+iterator.VariableValue.ToString() + "\n");
-                            //  MessageBox.Show( "inside iterate method variableModel: " + _rootModel.Data.variablesModel.VariablesList.ElementAt(0).VariableValue.ToString());
-
-                        }
-                        else
-                        {
-                            lastVariableOverflowed = true;
-                            iterator.VariableValue = iterator.VariableStartValue;
-                        }
-                    }
-
-                }
-                // RefreshVariableValuesInGUI(); not required -> done in evaluate
-            }
-
-            evaluate(null);
-
-            // reenable buffer updates
-            VariableUpdateDone(bufferUpdateLock);
         }
 
         /// <summary>
@@ -1038,7 +558,6 @@ namespace Controller.Variables
                 {
                     errorCollector.AddError(e.Message + "\nAt dynamic variable: " + dynamicVariable.VariableName, ErrorWindow.Variables, false, ErrorTypes.DynamicCompileError);
                 }
-
             }
 
             // reenable buffer updates
@@ -1048,43 +567,442 @@ namespace Controller.Variables
         }
 
         /// <summary>
-        /// Checks the usage of all variables
+        /// A function that will be called if the Buffer wants to evaluate the Variables
         /// </summary>
-        /// <param name="parameter">null</param>
-        public void CheckAllVariablesUsage(object parameter)
+        /// <param name="sender">unused</param>
+        /// <param name="e">unused</param>
+        public void EvaluateVariablesFromBuffer(object sender, EventArgs e)
         {
-            VariableUsageChecker checker = new VariableUsageChecker(_rootModel);
+            evaluate(null);
+        }
 
+        /// <summary>
+        /// Returns a variable by its name.
+        /// </summary>
+        /// <param name="name">Name of the variable to find</param>
+        /// <returns>the variable specified by name or null if it cannot be found</returns>
+        public VariableController GetByName(String name)
+        {
             foreach (VariableController variable in Variables)
             {
-                variable.ClearUsages();
-                string currentUsage = "";
-
-                foreach (VariableUsage usage in checker.GetUsagesOfVariable(variable.VariableName))
+                if (name.Equals(variable.VariableName))
                 {
-                    switch (usage.UsageType)
-                    {
-                        case VariableUsageType.CalibrationScript:
-                            currentUsage = String.Format("Calibration Script at ({0})", usage.ScriptLocation.GetLocationAsString());
-                            break;
-                        case VariableUsageType.Duration:
-                            currentUsage = String.Format("Step Duration at ({0})", usage.ScriptLocation.GetLocationAsString());
-                            break;
-                        case VariableUsageType.Value:
-                            currentUsage = String.Format("Step Value at ({0})", usage.ScriptLocation.GetLocationAsString());
-                            break;
-                        case VariableUsageType.DynamicVariable:
-                            currentUsage = String.Format("Dynamic Variable at ({0})", usage.ScriptLocation.GetLocationAsString());
-                            break;
-                        case VariableUsageType.PythonStep:
-                            currentUsage = String.Format("Python Step at ({0})", usage.ScriptLocation.GetLocationAsString());
-                            break;
-                    }
-
-                    variable.AddUsage(currentUsage);
+                    return variable;
                 }
-
             }
+            throw new Exception("Variable not found! Name: " + name);
+            //return null;
+        }
+
+        // ******************** properties ********************
+        public Root.RootController GetRootController()
+        {
+            return _parentController;
+        }
+
+        public ObservableCollection<VariableController> GetVariablesOfGroup(int groupKey)
+        {
+            ObservableCollection<VariableController> result = new ObservableCollection<VariableController>();
+
+            foreach (VariableController vController in Variables)
+            {
+                if (vController.TypeOfVariable == VariableType.VariableTypeStatic && vController.GroupIndex == groupKey)
+                    result.Add(vController);
+            }
+
+            return result;
+        }
+
+        public bool IsIteratorsLocked()
+        {
+            return _iteratorsLocked;
+        }
+
+        /// <summary>
+        /// Iterates the variables
+        /// </summary>
+        /// <param name="parameter">null</param>
+        public void iterate(object parameter)
+        {
+            // prevent inconsistencies and multiple updates on the buffer
+            Object bufferUpdateLock = VariableUpdateStart();
+
+            //createIterationPattern();
+            if (!_outputHandler.shuffleIterations)
+            {
+                shuffleIterationsCounter = 0;
+            }
+            if (shuffleIterationsCounter == 0 && _outputHandler.shuffleIterations)
+            {
+                createIterationPattern();
+            }
+
+            if (_outputHandler.shuffleIterations)
+            {
+                if (shuffleIterationsCounter >= iterationPattern.Count)
+                {
+                    shuffleIterationsCounter = 0;
+                }
+                for (int i = 0; i < VariablesIterator.Count; i++)
+                {
+                    VariablesIterator[i].VariableValue = iterationPattern[shuffleIterationsCounter][i].VariableValue;
+                }
+                shuffleIterationsCounter++;
+            }
+
+            if (!_outputHandler.shuffleIterations)
+            {
+                bool lastVariableOverflowed = true;
+
+                foreach (VariableController iterator in VariablesIterator)
+                {
+                    //  to be deleted
+                    //  VariableModel VariableModelToBeReset = _outputHandler.Model.Data.variablesModel.VariablesList.Find(x => x.VariableName == iterator._model.VariableName);
+                    // only increase variable if the one before had an overflow
+                    if (lastVariableOverflowed)
+                    {
+                        // first CheckAllVariablesUsage whether is this variable is not changing at all
+                        if (iterator.VariableStepValue == 0)
+                        {
+                            lastVariableOverflowed = true;
+                            iterator.VariableValue = iterator.VariableStartValue;
+                            //to be deleted
+                            //  VariableModelToBeReset.VariableValue = VariableModelToBeReset.VariableStartValue;
+                            continue;
+                        }
+
+                        double nextValue = iterator.VariableValue + iterator.VariableStepValue;
+                        //to be deleted
+                        //  nextValue = VariableModelToBeReset.VariableValue + VariableModelToBeReset.VariableStepValue;
+                        const double FLOATMARGIN = 1E-7;
+                        if ((nextValue <= iterator.VariableEndValue + FLOATMARGIN && iterator.VariableStepValue > 0) ||
+                            (nextValue >= iterator.VariableEndValue - FLOATMARGIN && iterator.VariableStepValue < 0))
+                        {
+                            lastVariableOverflowed = false;
+                            iterator.VariableValue = nextValue;
+                            //  _outputHandler.Model.Data.variablesModel.VariablesList.ElementAt(0).VariableValue = nextValue;
+                            //to be deleted
+                            //     VariableModelToBeReset.VariableValue = nextValue;
+                            //   MessageBox.Show("inside iterate method"+iterator.VariableValue.ToString() + "\n");
+                            //  MessageBox.Show( "inside iterate method variableModel: " + _rootModel.Data.variablesModel.VariablesList.ElementAt(0).VariableValue.ToString());
+                        }
+                        else
+                        {
+                            lastVariableOverflowed = true;
+                            iterator.VariableValue = iterator.VariableStartValue;
+                        }
+                    }
+                }
+                // RefreshVariableValuesInGUI(); not required -> done in evaluate
+            }
+
+            evaluate(null);
+
+            // reenable buffer updates
+            VariableUpdateDone(bufferUpdateLock);
+        }
+
+        /// <summary>
+        /// A function that will be called if the Buffer wants to iterate(and evaluate) the Variables
+        /// </summary>
+        /// <param name="sender">unused</param>
+        /// <param name="e">unused</param>
+        public void IterateVariablesFromBuffer(object sender, EventArgs e)
+        {
+            iterate(null);
+        }
+
+        public void moveDown(VariableController variableController)
+        {
+            if (variableController.TypeOfVariable == VariableType.VariableTypeIterator
+                || variableController.TypeOfVariable == VariableType.VariableTypeDynamic)
+            {
+                int currentModelIndex = _variablesModel.VariablesList.IndexOf(variableController._model);
+
+                if (currentModelIndex < _variablesModel.VariablesList.Count - 1)
+                {
+                    // find the variable to swap with
+                    VariableModel nextVariable = null;
+                    int nextModelIndex = currentModelIndex;
+
+                    do
+                    {
+                        ++nextModelIndex;
+                        nextVariable = _variablesModel.VariablesList[nextModelIndex];
+                    }
+                    while (!nextVariable.TypeOfVariable.Equals(variableController.TypeOfVariable)
+                        && nextModelIndex < _variablesModel.VariablesList.Count - 1);
+
+                    // if we managed to find a suitable step, swap it with the current one
+                    if (nextModelIndex < _variablesModel.VariablesList.Count - 1)
+                    {
+                        VariableModel currentVariable = _variablesModel.VariablesList[currentModelIndex];
+                        _variablesModel.VariablesList[currentModelIndex] = nextVariable;
+                        _variablesModel.VariablesList[nextModelIndex] = currentVariable;
+                        updatIterators();
+                        updateDynamics();
+                        countTotalNumberOfIterations();
+                    }
+                }
+            }
+            if (variableController.TypeOfVariable == VariableType.VariableTypeStatic)
+            {
+                variableController.GroupIndex++;
+                updateStatics();
+            }
+        }
+
+        public void moveUp(VariableController variableController)
+        {
+            if (variableController.TypeOfVariable == VariableType.VariableTypeIterator
+                || variableController.TypeOfVariable == VariableType.VariableTypeDynamic)
+            {
+                int currentModelIndex = _variablesModel.VariablesList.IndexOf(variableController._model);
+
+                if (currentModelIndex > 0)
+                {
+                    // find the variable to swap with
+                    VariableModel previousVariable = null;
+                    int previousModelIndex = currentModelIndex;
+
+                    do
+                    {
+                        --previousModelIndex;
+                        previousVariable = _variablesModel.VariablesList[previousModelIndex];
+                    }
+                    while (!previousVariable.TypeOfVariable.Equals(variableController.TypeOfVariable) && previousModelIndex > 0);
+
+                    // if we managed to find a suitable step, swap it with the current one
+                    if (previousModelIndex > 0)
+                    {
+                        VariableModel currentVariable = _variablesModel.VariablesList[currentModelIndex];
+                        _variablesModel.VariablesList[currentModelIndex] = previousVariable;
+                        _variablesModel.VariablesList[previousModelIndex] = currentVariable;
+                        updatIterators();
+                        updateDynamics();
+                        countTotalNumberOfIterations();
+                    }
+                }
+            }
+            else if (variableController.TypeOfVariable == VariableType.VariableTypeStatic)
+            {
+                if (variableController.GroupIndex > 0)
+                {
+                    variableController.GroupIndex--;
+                    updateStatics();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Called when some options that require the attention of this window change.
+        /// </summary>
+        public void NotifyOptionsChanged()
+        {
+            ReadOptions();
+        }
+
+        public void RefreshVariableValuesInGUI(bool refreshStatics, bool refreshIterators, bool refreshDynamics)
+        {
+            VariablesListChanged?.Invoke(this, new VariablesChangedEventArgs() { RefreshDynamics = refreshDynamics, RefreshIterators = refreshIterators, RefreshStatics = refreshStatics });
+        }
+
+        public void RemoveGroup(int groupKey)
+        {
+            if (GetVariablesOfGroup(groupKey).Count > 0)
+            {
+                MessageBox.Show("The group you are trying to remove contains variables. Please ensure that the group is empty before trying to remove it.",
+                    "Unable to Remove Group", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            else
+            {
+                GroupNames.Remove(groupKey);
+                GroupsExpandState.Remove(groupKey);
+                updateStatics();
+            }
+        }
+
+        public void RemoveVariable(VariableController variable)
+        {
+            this.CheckAllVariablesUsage(null);
+
+            if (variable.Used)
+            {
+                MessageBoxResult result = MessageBox.Show(String.Format("This Variable is used in \n{0}, you cannot delete it!", variable.UsagesAsString));
+            }
+            else
+            {
+                MessageBoxResult result = MessageBox.Show("Do you really want to delete this Variable?\n" + variable.VariableName, "Confirmation", MessageBoxButton.YesNo, MessageBoxImage.Question);
+                if (result == MessageBoxResult.Yes)
+                {
+                    VariableModel localModel = variable._model;
+                    Variables.Remove(variable);
+                    _variablesModel.deleteVariable(localModel);
+                    UpdateVariablesList();
+                }
+            }
+        }
+
+        public void RenameGroup(int groupKey, string groupName)
+        {
+            bool isNameUsed = false;
+            foreach (string name in GroupNames.Values)
+            {
+                if (groupName.Equals(name))
+                {
+                    isNameUsed = true;
+                    break;
+                }
+            }
+
+            if (isNameUsed)
+                MessageBox.Show("This group name is already in use please choose another one!", "Cannot Rename Group", MessageBoxButton.OK, MessageBoxImage.Error);
+            else
+            {
+                GroupNames[groupKey] = groupName;
+                updateStatics();
+            }
+        }
+
+        public void ResetIteratorValues()
+        {
+            // Ebaa 18.06.2018
+            // prevent inconsistencies and multiple updates on the buffer
+            // Object bufferUpdateLock = VariableUpdateStart();
+            foreach (VariableController iterator in VariablesIterator)
+            {
+                iterator.VariableValue = iterator.VariableStartValue;
+
+                // //test 11.06
+                // VariableModel VariableModelToBeReset = _outputHandler.Model.Data.variablesModel.VariablesList.Find(x => x.VariableName == iterator._model.VariableName);
+
+                ////test 11.06
+                // if (VariableModelToBeReset != null)
+                //  {
+                //      VariableModelToBeReset.VariableValue = iterator.VariableStartValue;
+                //  }
+                ////// MessageBox.Show("Iterator:"+ iterator._model.VariableName+"\n Value:"+ iterator.VariableValue+ "\n Model Vlaue:"+iterator._model.VariableValue);
+            }
+            RefreshVariableValuesInGUI(false, true, true);
+            // Ebaa 18.06.2018
+            // reenable buffer updates
+            // VariableUpdateDone(bufferUpdateLock);
+        }
+
+        public void ResetIteratorValuesFromBuffer(object sender, EventArgs e)
+        {
+            ResetIteratorValues();
+            evaluate(null);
+        }
+
+        /// <summary>
+        /// Sets a new RootModel for the variables
+        /// </summary>
+        /// <param name="variablesModel">the model which will replace the old one</param>
+        public void SetNewRootModel(RootModel rootModel)
+        {
+            this._rootModel = rootModel;
+            groupsExpandState = null;
+        }
+
+        /// <summary>
+        /// Sets a new model for the variables
+        /// </summary>
+        /// <param name="variablesModel">the model which will replace the old one</param>
+        public void SetNewVariablesModel(VariablesModel variablesModel)
+        {
+            this._variablesModel = variablesModel;
+            Variables.Clear();
+            foreach (VariableModel variable in variablesModel.VariablesList)
+            {
+                Variables.Add(new VariableController(variable, this));
+            }
+            UpdateVariablesList();
+            countTotalNumberOfIterations();
+        }
+
+        public List<TValue> Shuffle<TValue>(
+                   List<TValue> source)
+        {
+            Random r = new Random();
+            return source.OrderBy(x => r.Next())
+               .ToList();
+        }
+
+        public void updateDynamics()
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("VariablesDynamic"));
+        }
+
+        public void updateStatics()
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("VariablesStatic"));
+        }
+
+        /// <summary>
+        /// This function gets called when the Lists of Variables are changed.
+        /// </summary>
+        public void UpdateVariablesList()//This function deletes the focus of an input field
+        {
+            if (PropertyChanged != null)
+            {
+                PropertyChanged(this, new PropertyChangedEventArgs("VariablesStatic"));
+                PropertyChanged(this, new PropertyChangedEventArgs("VariablesIterator"));
+                PropertyChanged(this, new PropertyChangedEventArgs("VariablesDynamic"));
+            }
+
+            VariablesListChanged?.Invoke(this, new VariablesChangedEventArgs() { RefreshStatics = true, RefreshIterators = true, RefreshDynamics = true });
+        }
+
+        public void UpdateVariablesListNoValues()//This function deletes the focus of an input field
+        {
+            if (PropertyChanged != null)
+            {
+                PropertyChanged(this, new PropertyChangedEventArgs("VariablesStatic"));
+                PropertyChanged(this, new PropertyChangedEventArgs("VariablesIterator"));
+                PropertyChanged(this, new PropertyChangedEventArgs("VariablesDynamic"));
+            }
+        }
+
+        public void UpdateWindowsList()
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("WindowsList"));
+        }
+
+        public void updatIterators()
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("VariablesIterator"));
+        }
+
+        /// <summary>
+        /// re-enables and triggers the CopyToBuffer function if the object in the argument matches the _variableUpdateLockObject
+        /// </summary>
+        /// <param name="lockObject">lock/unlock object</param>
+        public bool VariableUpdateDone(Object lockObject)
+        {
+            //if (_variableUpdateLockObject == lockObject)
+            //{
+            //    _variableUpdateLockObject = null;
+            //    _parentController.EnableCopyToBufferAndCopyChanges();
+            //}
+
+            return _parentController.BulkUpdateEnd(lockObject);
+        }
+
+        /// <summary>
+        /// disables the CopyToBuffer function until a VariablesUpdateDone with the object _variableUpdateLockObject is called
+        /// </summary>
+        public Object VariableUpdateStart()
+        {
+            //var lockObject = new object();
+            //if (_variableUpdateLockObject == null)//Only who has the first lock wins!!
+            //{
+            //    _variableUpdateLockObject = lockObject;
+            //}
+            //_parentController.DisableCopyToBuffer();
+            //return lockObject;
+
+            return _parentController.BulkUpdateStart();
         }
 
         /// <summary>
@@ -1096,6 +1014,45 @@ namespace Controller.Variables
             _parentController = parentController;
         }
 
+        // ******************** lock stuff ********************
+        /// <summary>
+        /// avoid inconsistency the data should not be copied to the buffer until all updates are done. In _variableUpdateLockObject the very first lock object is stored, all objects from sub updates are not stored. The updateVariablesListFromParent is prevented until the lock is released.
+        /// </summary>
+        //private Object _variableUpdateLockObject = null;
+        private void LockIterators(object sender, EventArgs e)
+        {
+            this.LoseFocus(null, null);
+
+            // ResetIteratorValues();
+            evaluate(null);
+            _iteratorsLocked = true;
+            System.Console.WriteLine("Locked iterators");
+            foreach (VariableController iterator in VariablesIterator)
+            {
+                iterator.VariableLocked = true;
+            }
+        }
+
+        /// <summary>
+        /// Moves the variable to a new group with a default name.
+        /// </summary>
+        /// <param name="parameter">The <see cref=" VariableController"/> of the corresponding variable.</param>
+        private void MoveVariableToNewGroup(object parameter)
+        {
+            VariableController variable = (VariableController)parameter;
+            int groupKey = -1;
+
+            foreach (int key in GroupNames.Keys)
+                if (key > groupKey)
+                    groupKey = key;
+
+            groupKey++;
+            GroupNames.Add(groupKey, "New Group " + groupKey);
+            GroupsExpandState.Add(groupKey, true);
+            variable.GroupIndex = groupKey;
+            updateStatics();
+        }
+
         /// <summary>
         /// Reads the related options
         /// </summary>
@@ -1104,18 +1061,48 @@ namespace Controller.Variables
             StaticVariablesPerGroupColumn = OptionsManager.GetInstance().GetOptionValueByName<int>(OptionNames.VARIABLES_STATIC_GROUP_HEIGHT);
         }
 
-        /// <summary>
-        /// Called when some options that require the attention of this window change.
-        /// </summary>
-        public void NotifyOptionsChanged()
+        private void UnlockIterators(object sender, EventArgs e)
         {
-            ReadOptions();
+            _iteratorsLocked = false;
+            foreach (VariableController iterator in VariablesIterator)
+            {
+                iterator.VariableLocked = false;
+            }
+            System.Console.WriteLine("Unlocked iterators");
         }
 
-        public void UpdateWindowsList()
+        /*public void UpdateSpecificVarialbesCollection(CustomElements.VariableType varType)
         {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("WindowsList"));
+            switch (varType)
+            {
+                case VariableType.VariableTypeStatic:
+                        if (PropertyChanged != null)
+                        {
+                            PropertyChanged(this, new PropertyChangedEventArgs("VariablesStatic"));
+                        }
+                        break;
+
+                case VariableType.VariableTypeIterator:
+                        if (PropertyChanged != null)
+                        {
+                            PropertyChanged(this, new PropertyChangedEventArgs("VariablesIterator"));
+                        }
+                        break;
+
+                case VariableType.VariableTypeDynamic:
+                        if (PropertyChanged != null)
+                        {
+                            PropertyChanged(this, new PropertyChangedEventArgs("VariablesDynamic"));
+                        }
+                        break;
         }
+            //System.Console.Write("b\n");
+            if (VariablesListChanged != null)
+            {
+                VariablesListChanged(this, null);
+            }
+        }*/
+        /* refresh the gui */
 
         #region IController Members
 
@@ -1127,6 +1114,6 @@ namespace Controller.Variables
             _parentController.CopyToBuffer();
         }
 
-        #endregion
+        #endregion IController Members
     }
 }

--- a/View/View/Data/Steps/StepAnalogFileView.xaml
+++ b/View/View/Data/Steps/StepAnalogFileView.xaml
@@ -6,6 +6,7 @@
              xmlns:CustomElements="clr-namespace:CustomElements.CloseButton;assembly=CustomElements"
              xmlns:SubmitTextBox="clr-namespace:CustomElements.SubmitTextBox;assembly=CustomElements"
              xmlns:NonFadingButton="clr-namespace:CustomElements.NonFadingButton;assembly=CustomElements" mc:Ignorable="d"
+             xmlns:steps="clr-namespace:View.Data.Steps"
              d:DesignHeight="80" MinWidth="120" MaxWidth="120" Width="119.532">
     <UserControl.Resources>
         <ResourceDictionary Source="pack://application:,,,/CustomElements;component/CustomDictionary.xaml" />
@@ -16,17 +17,15 @@
         <Grid>
 
             <Grid.RowDefinitions>
-                <RowDefinition Height="20*" />
-                <RowDefinition Height="20*" />
-                <RowDefinition Height="20*" />
-                <RowDefinition Height="20*" />
-                <!--<RowDefinition Height="21*"/>-->
+                <RowDefinition Height="1*" />
+                <RowDefinition Height="1*" />
+                <RowDefinition Height="1*" />
+                <RowDefinition Height="1*" />
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition />
-                <ColumnDefinition Width="32*"/>
+                <ColumnDefinition Width="35"/>
                 <ColumnDefinition Width="47*" />
-                <ColumnDefinition Width="38*"/>
+                <ColumnDefinition Width="35"/>
             </Grid.ColumnDefinitions>
             <DockPanel Grid.ColumnSpan="4" VerticalAlignment="Stretch">
                 <NonFadingButton:NonFadingButton Width="20" Command="{Binding SetMessage}"  Background="{Binding SetMessageColor}" ToolTipService.IsEnabled="{Binding SetMessageShowTooltip}" ToolTip="{Binding SetMessageMessage}"/>
@@ -37,27 +36,15 @@
             </DockPanel>
 
             <SubmitTextBox:SubmitTextBox HorizontalContentAlignment="Right" VerticalContentAlignment="Center"
-                                         HorizontalAlignment="Stretch" Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2"  VerticalAlignment="Stretch" Margin="0,1,1,1" Padding="0" Text="{Binding FileName}"/>
-            <NonFadingButton:NonFadingButton FontSize="10" Content="Open" Grid.Row="1" Grid.Column="3" Padding="0"
+                                         HorizontalAlignment="Stretch" Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"  VerticalAlignment="Stretch" Margin="0,1,1,1" Padding="0" Text="{Binding FileName}"/>
+            <NonFadingButton:NonFadingButton FontSize="10" Content="Open" Grid.Row="1" Grid.Column="2" Padding="0"
                                              Margin="1" Command="{Binding OpenFileDialog}"/>
             <TextBlock Text="Dur.:" TextAlignment="Right" HorizontalAlignment="Stretch" Grid.Row="2"
-                       VerticalAlignment="Stretch" Margin="0,1,1,2" Padding="0" Grid.Column="1" />
-            <TextBox TextAlignment="Center" HorizontalAlignment="Stretch" Grid.Row="2" Grid.Column="2" Padding="0"
-                       Margin="1,2" Text="{Binding Duration, Mode=OneWay}" Background="LightGray" IsReadOnly="True"/>
-            <TextBlock Text="Start:" TextAlignment="Right" HorizontalAlignment="Stretch" Grid.Row="3"
-                       VerticalAlignment="Stretch" Padding="1" Foreground="Blue" Grid.ColumnSpan="2">
-                <TextBlock.ContextMenu>
-                    <ContextMenu>
-                        <MenuItem Header="Insert" HorizontalAlignment="Left" Command="{Binding Insert}"></MenuItem>
-                        <MenuItem Header="Move left" HorizontalAlignment="Left" Command="{Binding MoveLeft}"></MenuItem>
-                        <MenuItem Header="Move right"  HorizontalAlignment="Left" Command="{Binding MoveRight}"></MenuItem>
-                    </ContextMenu>
-                </TextBlock.ContextMenu>
-            </TextBlock>
-            <TextBox TextAlignment="Center" HorizontalAlignment="Stretch" Grid.Row="3" Grid.Column="2" Padding="0"
-                       Margin="1,0" Text="{Binding StartTime, Mode=OneWay}" Background="LightGray" IsReadOnly="True"/>
-            <TextBlock TextAlignment="Left" Grid.Column="3" Margin="1,1,0,2" Grid.Row="2" TextWrapping="Wrap" Text="{Binding Unit}" Padding="0"/>
-            <TextBlock TextAlignment="Left" Grid.Column="3" Margin="1,0,1,1" Grid.Row="3" TextWrapping="Wrap" Text="{Binding Unit}" Padding="0"/>
+                       VerticalAlignment="Stretch" Margin="0,1,1,2" Padding="0" Grid.Column="0" />
+            <TextBox TextAlignment="Center" HorizontalAlignment="Stretch" Grid.Row="2" Grid.Column="1" Padding="0"
+                       Margin="1" Text="{Binding Duration, Mode=OneWay}" Background="LightGray" IsReadOnly="True"/>
+            <TextBlock TextAlignment="Left" Grid.Column="2" Margin="1,1,0,2" Grid.Row="2" TextWrapping="Wrap" Text="{Binding Unit}" Padding="0"/>
+            <steps:StepBasicView Grid.Column="0" Grid.ColumnSpan="3" Grid.Row="3"></steps:StepBasicView>
         </Grid>
     </Border>
 </UserControl>

--- a/View/View/Data/Steps/StepAnalogFileView.xaml
+++ b/View/View/Data/Steps/StepAnalogFileView.xaml
@@ -36,7 +36,7 @@
             </DockPanel>
 
             <SubmitTextBox:SubmitTextBox HorizontalContentAlignment="Right" VerticalContentAlignment="Center"
-                                         HorizontalAlignment="Stretch" Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"  VerticalAlignment="Stretch" Margin="0,1,1,1" Padding="0" Text="{Binding FileName}"/>
+                                         HorizontalAlignment="Stretch" Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"  VerticalAlignment="Stretch" Margin="1" Padding="0" Text="{Binding FileName}"/>
             <NonFadingButton:NonFadingButton FontSize="10" Content="Open" Grid.Row="1" Grid.Column="2" Padding="0"
                                              Margin="1" Command="{Binding OpenFileDialog}"/>
             <TextBlock Text="Dur.:" TextAlignment="Right" HorizontalAlignment="Stretch" Grid.Row="2"

--- a/View/View/Data/Steps/StepAnalogRampView.xaml
+++ b/View/View/Data/Steps/StepAnalogRampView.xaml
@@ -6,6 +6,7 @@
              xmlns:CustomElements="clr-namespace:CustomElements.SubmitTextBox;assembly=CustomElements"
              xmlns:CloseButton="clr-namespace:CustomElements.CloseButton;assembly=CustomElements"
              xmlns:nonFadingButton="clr-namespace:CustomElements.NonFadingButton;assembly=CustomElements"
+             xmlns:steps="clr-namespace:View.Data.Steps"
              mc:Ignorable="d"
              d:DesignHeight="80" d:DesignWidth="120" MinWidth="120" MaxWidth="120" >
 	<UserControl.Resources>
@@ -21,9 +22,9 @@
 				<!--<RowDefinition Height="21*"/>-->
 			</Grid.RowDefinitions>
 			<Grid.ColumnDefinitions>
-				<ColumnDefinition Width="45*" />
+				<ColumnDefinition Width="35" />
 				<ColumnDefinition Width="65*" />
-				<ColumnDefinition Width="53*"/>
+				<ColumnDefinition Width="35"/>
 			</Grid.ColumnDefinitions>
 			<DockPanel Grid.ColumnSpan="3" VerticalAlignment="Stretch" HorizontalAlignment="Right" Width="118">
 				<nonFadingButton:NonFadingButton Width="20" Command="{Binding SetMessage}"  Background="{Binding SetMessageColor}" ToolTipService.IsEnabled="{Binding SetMessageShowTooltip}" ToolTip="{Binding SetMessageMessage}"/>
@@ -36,7 +37,7 @@
 			<TextBlock Text="Value:" TextAlignment="Right" HorizontalAlignment="Stretch" Grid.Row="1"
                        VerticalAlignment="Stretch" Margin="1" Padding="0" />
 			<CustomElements:SubmitTextBox VerticalContentAlignment="Center" HorizontalAlignment="Stretch" HorizontalContentAlignment="Right"
-                                          VerticalAlignment="Stretch" Grid.Row="1" Grid.Column="1" Padding="0" Margin="1" Text="{Binding Value, Mode=TwoWay}" Background="{Binding ValueColor, Mode=OneWay}" IsReadOnly="{Binding ValueIsReadOnly, Mode=OneWay}" ToolTipService.IsEnabled="{Binding ValueIsReadOnly, Mode=OneWay}" ToolTip="{Binding ValueVariableName, Mode=OneWay}" TextAlignment="Center">
+                                          MinWidth="40" VerticalAlignment="Stretch" Grid.Row="1" Grid.Column="1" Padding="0" Margin="1" Text="{Binding Value, Mode=TwoWay}" Background="{Binding ValueColor, Mode=OneWay}" IsReadOnly="{Binding ValueIsReadOnly, Mode=OneWay}" ToolTipService.IsEnabled="{Binding ValueIsReadOnly, Mode=OneWay}" ToolTip="{Binding ValueVariableName, Mode=OneWay}" TextAlignment="Center">
 				<CustomElements:SubmitTextBox.ContextMenu>
 					<ContextMenu>
 						<MenuItem Name="userInputValueMenu" Header="User Input" HorizontalAlignment="Left" Command="{Binding UserInputValue}"/>
@@ -49,32 +50,20 @@
 
 			<TextBlock Text="Dur.:" TextAlignment="Right" HorizontalAlignment="Stretch" Grid.Row="2"
                        VerticalAlignment="Stretch" Margin="1" Padding="0" ></TextBlock>
-			<CustomElements:SubmitTextBox VerticalContentAlignment="Center" HorizontalAlignment="Stretch" HorizontalContentAlignment="Right"
-                                          VerticalAlignment="Stretch" Grid.Row="2" Grid.Column="1" Padding="0" Margin="1" Text="{Binding Duration, Mode=TwoWay}" Background="{Binding DurationColor, Mode=OneWay}" IsReadOnly="{Binding DurationIsReadOnly, Mode=OneWay}" ToolTipService.IsEnabled="{Binding DurationIsReadOnly, Mode=OneWay}" ToolTip="{Binding DurationVariableName, Mode=OneWay}" TextAlignment="Center">
-				<CustomElements:SubmitTextBox.ContextMenu>
-					<ContextMenu Name="durCM">
-						<MenuItem Name="userInputDurationMenu"  HorizontalAlignment="Left"  Header="User Input" Command="{Binding UserInputDuration}" />
-						<MenuItem Name="staticMenu2" Header="Statics"  HorizontalAlignment="Left"   ItemsSource="{Binding staticNamesDuration}" />
-						<MenuItem Name="iteratorMenu2" Header="Iterators" HorizontalAlignment="Left"   ItemsSource="{Binding iteratorNamesDuration}" />
-						<MenuItem Name="dynamicMenu2" Header="Dynamics" HorizontalAlignment="Left"  ItemsSource="{Binding dynamicNamesDuration}" />
-					</ContextMenu>
-				</CustomElements:SubmitTextBox.ContextMenu>
-			</CustomElements:SubmitTextBox>
-			<TextBlock Text="Start:" TextAlignment="Right" HorizontalAlignment="Stretch" Grid.Row="3"
-                       VerticalAlignment="Stretch" Padding="1" Margin="0" Foreground="Blue">
-				<TextBlock.ContextMenu>
-					<ContextMenu>
-						<MenuItem Header="Insert" HorizontalAlignment="Left" Command="{Binding Insert}"></MenuItem>
-						<MenuItem Header="Move left" HorizontalAlignment="Left" Command="{Binding MoveLeft}"></MenuItem>
-						<MenuItem Header="Move right"  HorizontalAlignment="Left" Command="{Binding MoveRight}"></MenuItem>
-					</ContextMenu>
-				</TextBlock.ContextMenu>
-			</TextBlock>
-			<TextBox TextAlignment="Center" HorizontalAlignment="Stretch" Grid.Row="3" Grid.Column="1" Padding="0"
-                       Margin="1,1,1,0" Height="17" Text="{Binding StartTime, Mode=OneWay}" Background="LightGray" IsReadOnly="True"/>
-			<TextBlock TextAlignment="Left" Grid.Column="2" Margin="1,1,0,0" Grid.Row="1" TextWrapping="Wrap" Text="{Binding InputUnit}" Padding="0"/>
+            <CustomElements:SubmitTextBox VerticalContentAlignment="Center" HorizontalAlignment="Stretch" HorizontalContentAlignment="Right"
+                                          MinWidth="40" VerticalAlignment="Stretch" Grid.Row="2" Grid.Column="1" Padding="0" Margin="1" Text="{Binding Duration, Mode=TwoWay}" Background="{Binding DurationColor, Mode=OneWay}" IsReadOnly="{Binding DurationIsReadOnly, Mode=OneWay}" ToolTipService.IsEnabled="{Binding DurationIsReadOnly, Mode=OneWay}" ToolTip="{Binding DurationVariableName, Mode=OneWay}" TextAlignment="Center">
+                <CustomElements:SubmitTextBox.ContextMenu>
+                    <ContextMenu Name="durCM">
+                        <MenuItem Name="userInputDurationMenu"  HorizontalAlignment="Left"  Header="User Input" Command="{Binding UserInputDuration}" />
+                        <MenuItem Name="staticMenu2" Header="Statics"  HorizontalAlignment="Left"   ItemsSource="{Binding staticNamesDuration}" />
+                        <MenuItem Name="iteratorMenu2" Header="Iterators" HorizontalAlignment="Left"   ItemsSource="{Binding iteratorNamesDuration}" />
+                        <MenuItem Name="dynamicMenu2" Header="Dynamics" HorizontalAlignment="Left"  ItemsSource="{Binding dynamicNamesDuration}" />
+                    </ContextMenu>
+                </CustomElements:SubmitTextBox.ContextMenu>
+            </CustomElements:SubmitTextBox>
+            <TextBlock TextAlignment="Left" Grid.Column="2" Margin="1,1,0,0" Grid.Row="1" TextWrapping="Wrap" Text="{Binding InputUnit}" Padding="0"/>
 			<TextBlock TextAlignment="Left" Grid.Column="2" Margin="1" Grid.Row="2" TextWrapping="Wrap" Text="{Binding Unit}" Padding="0"/>
-			<TextBlock TextAlignment="Left" Grid.Column="2" Margin="1" Grid.Row="3" TextWrapping="Wrap" Text="{Binding Unit}" Padding="0"/>
+			<steps:StepBasicView Grid.Column="0" Grid.ColumnSpan="3" Grid.Row="3"></steps:StepBasicView>
 		</Grid>
 	</Border>
 </UserControl>

--- a/View/View/Data/Steps/StepBasicView.xaml
+++ b/View/View/Data/Steps/StepBasicView.xaml
@@ -1,0 +1,32 @@
+﻿<UserControl x:Class="View.Data.Steps.StepBasicView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:View.Data.Steps"
+             mc:Ignorable="d" 
+             d:DesignHeight="40" d:DesignWidth="120">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="35" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="35" />
+        </Grid.ColumnDefinitions>
+        <TextBlock Text="Start:" TextAlignment="Right" HorizontalAlignment="Stretch" Grid.Column="0"
+                       VerticalAlignment="Center" Padding="1" Margin="0" Foreground="Blue">
+            <TextBlock.ContextMenu>
+                <ContextMenu>
+                    <MenuItem Header="Insert" Command="{Binding Insert}"></MenuItem>
+                    <MenuItem Header="Move left" Command="{Binding MoveLeft}"></MenuItem>
+                    <MenuItem Header="Move right"  Command="{Binding MoveRight}"></MenuItem>
+                </ContextMenu>
+            </TextBlock.ContextMenu>
+        </TextBlock>
+        <TextBox TextAlignment="Center" HorizontalAlignment="Stretch" Grid.Column="1" Padding="0" 
+                       Margin="1" Text="{Binding StartTime, Mode=OneWay}" Background="LightGray" IsReadOnly="True"/>
+        <TextBlock TextAlignment="Left" Grid.Column="2" Margin="1,0,1,1" TextWrapping="Wrap" Text="{Binding Unit}" Padding="0"/>
+    </Grid>
+</UserControl>

--- a/View/View/Data/Steps/StepBasicView.xaml
+++ b/View/View/Data/Steps/StepBasicView.xaml
@@ -26,7 +26,7 @@
             </TextBlock.ContextMenu>
         </TextBlock>
         <TextBox TextAlignment="Center" HorizontalAlignment="Stretch" Grid.Column="1" Padding="0" 
-                       Margin="1" Text="{Binding StartTime, Mode=OneWay}" Background="LightGray" IsReadOnly="True"/>
+                       Margin="1" Text="{Binding StartTime, Mode=OneWay}" Background="LightGray" IsReadOnly="True" PreviewKeyDown="TextBox_PreviewKeyDown"/>
         <TextBlock TextAlignment="Left" Grid.Column="2" Margin="1,0,1,1" TextWrapping="Wrap" Text="{Binding Unit}" Padding="0"/>
     </Grid>
 </UserControl>

--- a/View/View/Data/Steps/StepBasicView.xaml.cs
+++ b/View/View/Data/Steps/StepBasicView.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace View.Data.Steps
+{
+    /// <summary>
+    /// Interaction logic for StepBasicView.xaml
+    /// </summary>
+    public partial class StepBasicView : UserControl
+    {
+        public StepBasicView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/View/View/Data/Steps/StepBasicView.xaml.cs
+++ b/View/View/Data/Steps/StepBasicView.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Controller.Data.Steps;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -23,6 +24,25 @@ namespace View.Data.Steps
         public StepBasicView()
         {
             InitializeComponent();
+        }
+
+        private void TextBox_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            var realSender = (TextBox)sender;
+            var dataContext = (StepBasicController)realSender.DataContext;
+            if (Keyboard.Modifiers == ModifierKeys.Control)
+            {
+                if (e.Key == Key.Left)
+                {
+                    dataContext.DoMoveLeft(dataContext);
+                    e.Handled = true;
+                }
+                else if (e.Key == Key.Right)
+                {
+                    dataContext.DoMoveRight(dataContext);
+                    e.Handled = true;
+                }
+            }
         }
     }
 }

--- a/View/View/Data/Steps/StepBasicView.xaml.cs
+++ b/View/View/Data/Steps/StepBasicView.xaml.cs
@@ -30,6 +30,7 @@ namespace View.Data.Steps
         {
             var realSender = (TextBox)sender;
             var dataContext = (StepBasicController)realSender.DataContext;
+
             if (Keyboard.Modifiers == ModifierKeys.Control)
             {
                 if (e.Key == Key.Left)

--- a/View/View/Data/Steps/StepDigitalFileView.xaml
+++ b/View/View/Data/Steps/StepDigitalFileView.xaml
@@ -6,6 +6,7 @@ xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:CustomElements="clr-namespace:CustomElements.CloseButton;assembly=CustomElements"
              xmlns:SubmitTextBox="clr-namespace:CustomElements.SubmitTextBox;assembly=CustomElements"
              xmlns:NonFadingButton="clr-namespace:CustomElements.NonFadingButton;assembly=CustomElements" mc:Ignorable="d"
+             xmlns:steps="clr-namespace:View.Data.Steps"
              d:DesignHeight="80" d:DesignWidth="120" MinWidth="120" MaxWidth="120">
     <UserControl.Resources>
         <ResourceDictionary Source="pack://application:,,,/CustomElements;component/CustomDictionary.xaml" />
@@ -16,14 +17,14 @@ xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         <Grid>
 
             <Grid.RowDefinitions>
-                <RowDefinition Height="20*" />
-                <RowDefinition Height="20*" />
-                <RowDefinition Height="20*" />
+                <RowDefinition Height="1*" />
+                <RowDefinition Height="1*" />
+                <RowDefinition Height="1*" />
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="45*" />
+                <ColumnDefinition Width="35" />
                 <ColumnDefinition Width="65*" />
-                <ColumnDefinition Width="53*"/>
+                <ColumnDefinition Width="35"/>
             </Grid.ColumnDefinitions>
             <DockPanel Grid.ColumnSpan="3" VerticalAlignment="Stretch">
                 <NonFadingButton:NonFadingButton Width="20" Command="{Binding SetMessage}"  Background="{Binding SetMessageColor}" ToolTipService.IsEnabled="{Binding SetMessageShowTooltip}" ToolTip="{Binding SetMessageMessage}"/>
@@ -37,20 +38,7 @@ xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                                          HorizontalAlignment="Stretch" Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"  VerticalAlignment="Stretch" Margin="1" Padding="0" Text="{Binding FileName}"/>
             <NonFadingButton:NonFadingButton FontSize="10" Content="Open" Grid.Row="1" Grid.Column="2" Padding="0"
                                              Margin="1" Command="{Binding OpenFileDialog}"/>
-
-            <TextBlock Text="Start:" TextAlignment="Right" HorizontalAlignment="Stretch" Grid.Row="2"
-                       VerticalAlignment="Stretch" Padding="1" Margin="0" Foreground="Blue">
-                <TextBlock.ContextMenu>
-                    <ContextMenu>
-                        <MenuItem Header="Insert" HorizontalAlignment="Left" Command="{Binding Insert}"></MenuItem>
-                        <MenuItem Header="Move left" HorizontalAlignment="Left" Command="{Binding MoveLeft}"></MenuItem>
-                        <MenuItem Header="Move right"  HorizontalAlignment="Left" Command="{Binding MoveRight}"></MenuItem>
-                    </ContextMenu>
-                </TextBlock.ContextMenu>
-            </TextBlock>
-            <TextBox TextAlignment="Center" HorizontalAlignment="Stretch" Grid.Row="2" Grid.Column="1" Padding="0"
-                       Margin="1,1,1,0" Height="17" Text="{Binding StartTime, Mode=OneWay}" Background="LightGray" IsReadOnly="True"/>
-            <TextBlock TextAlignment="Left" Grid.Column="2" Margin="1" Grid.Row="2" TextWrapping="Wrap" Text="{Binding Unit}" Padding="0"/>
+            <steps:StepBasicView Grid.Column="0" Grid.ColumnSpan="3" Grid.Row="2"></steps:StepBasicView>
         </Grid>
     </Border>
 </UserControl>

--- a/View/View/Data/Steps/StepDigitalRamp.xaml
+++ b/View/View/Data/Steps/StepDigitalRamp.xaml
@@ -5,46 +5,35 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:CustomElements="clr-namespace:CustomElements.CloseButton;assembly=CustomElements"
              xmlns:SubmitTextBox="clr-namespace:CustomElements.SubmitTextBox;assembly=CustomElements"
+             xmlns:steps="clr-namespace:View.Data.Steps"
              xmlns:NonFadingButton="clr-namespace:CustomElements.NonFadingButton;assembly=CustomElements" mc:Ignorable="d"
-             d:DesignWidth="110" MinWidth="130" MaxWidth="130">
+             d:DesignWidth="140" MinWidth="145" MaxWidth="145">
     <UserControl.Resources>
         <ResourceDictionary Source="pack://application:,,,/CustomElements;component/CustomDictionary.xaml" />
     </UserControl.Resources>
     <Border BorderBrush="Gray" BorderThickness="1" >
-        <Grid HorizontalAlignment="Left" Width="128" >
+        <Grid HorizontalAlignment="Stretch" >
             <Grid.RowDefinitions>
-                <RowDefinition Height="20*" />
-                <RowDefinition Height="20*" />
-                <RowDefinition Height="20*" />
+                <RowDefinition Height="1*" />
+                <RowDefinition Height="1*" />
+                <RowDefinition Height="1*" />
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="3*" />
-                <ColumnDefinition Width="5*"/>
-                <ColumnDefinition Width="2*"/>
-                <ColumnDefinition Width="21*"/>
-                <ColumnDefinition Width="62*" />
-                <ColumnDefinition Width="18*"/>
-                <ColumnDefinition Width="17*" />
+                <ColumnDefinition Width="35" />
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="35"/>
+                <ColumnDefinition Width="25"/>
             </Grid.ColumnDefinitions>
-            <DockPanel Grid.ColumnSpan="7" VerticalAlignment="Stretch">
+            <DockPanel Grid.ColumnSpan="4" VerticalAlignment="Stretch">
                 <NonFadingButton:NonFadingButton Width="20" Command="{Binding SetMessage}" Background="{Binding SetMessageColor}"  ToolTipService.IsEnabled="{Binding SetMessageShowTooltip}" ToolTip="{Binding SetMessageMessage}"/>
                 <CustomElements:CloseButton DockPanel.Dock="Right" VerticalAlignment="Center" MinHeight="15" Margin="1" Command="{Binding RemoveItem}"/>
-                <ComboBox Padding="2,0" DockPanel.Dock="Right" Margin="1" MinWidth="50" MinHeight="14" ItemsSource="{Binding DigitalTypeList}" SelectedValue="{Binding DigitalTypeSelected}"/>
+                <ComboBox Padding="2,0" DockPanel.Dock="Right" Margin="1" MinWidth="75" MinHeight="14" ItemsSource="{Binding DigitalTypeList}" SelectedValue="{Binding DigitalTypeSelected}"/>
             </DockPanel>
             <Label Content="Dur.:" HorizontalContentAlignment="Right" VerticalContentAlignment="Center"
-                   HorizontalAlignment="Stretch" Grid.Row="1" VerticalAlignment="Stretch" Margin="1" Padding="0" Grid.ColumnSpan="4" />
-            <TextBlock Text="Start:" TextAlignment="Right"
-                   HorizontalAlignment="Stretch" Grid.Row="2" VerticalAlignment="Stretch" Margin="1" Padding="0" Foreground="Blue" Grid.ColumnSpan="4">
-                <TextBlock.ContextMenu>
-                    <ContextMenu>
-                        <MenuItem Header="Insert" HorizontalAlignment="Left" Command="{Binding Insert}"></MenuItem>
-                        <MenuItem Header="Move left" HorizontalAlignment="Left" Command="{Binding MoveLeft}"></MenuItem>
-                        <MenuItem Header="Move right"  HorizontalAlignment="Left" Command="{Binding MoveRight}"></MenuItem>
-                    </ContextMenu>
-                </TextBlock.ContextMenu>
-            </TextBlock>
-            <SubmitTextBox:SubmitTextBox HorizontalContentAlignment="Right" VerticalContentAlignment="Center"
-                                         HorizontalAlignment="Stretch" Grid.Row="1" Grid.Column="4" VerticalAlignment="Stretch" Margin="1,1,1,1" Padding="0" Text="{Binding Duration}" Background="{Binding DurationColor, Mode=OneWay}" IsReadOnly="{Binding DurationIsReadOnly, Mode=OneWay}" ToolTipService.IsEnabled="{Binding DurationIsReadOnly, Mode=OneWay}" ToolTip="{Binding DurationVariableName, Mode=OneWay}" Name="DurTextBox">
+                   HorizontalAlignment="Stretch" Grid.Row="1" VerticalAlignment="Stretch" Margin="1" Padding="0"  />
+
+            <SubmitTextBox:SubmitTextBox HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                                         HorizontalAlignment="Stretch" Grid.Row="1" Grid.Column="1" VerticalAlignment="Stretch" Margin="1,1,1,1" Padding="0" Text="{Binding Duration}" Background="{Binding DurationColor, Mode=OneWay}" IsReadOnly="{Binding DurationIsReadOnly, Mode=OneWay}" ToolTipService.IsEnabled="{Binding DurationIsReadOnly, Mode=OneWay}" ToolTip="{Binding DurationVariableName, Mode=OneWay}" Name="DurTextBox">
                 <SubmitTextBox:SubmitTextBox.ContextMenu>
                     <ContextMenu>
                         <MenuItem Name="userInputDurationMenu" Header="User Input"  HorizontalAlignment="Left" Command="{Binding UserInputDuration}"/>
@@ -54,17 +43,10 @@
                     </ContextMenu>
                 </SubmitTextBox:SubmitTextBox.ContextMenu>
             </SubmitTextBox:SubmitTextBox>
-            <TextBlock TextAlignment="Right" HorizontalAlignment="Stretch" Text="{Binding StartTime}"
-                   Grid.Row="2" Grid.Column="4" VerticalAlignment="Stretch" Margin="1" Padding="0" />
-            <NonFadingButton:NonFadingButton Grid.Column="6" Grid.Row="1" Grid.RowSpan="2" Background="{Binding ButtonColor}" Command="{Binding DigitalButton}"/>
-            <TextBlock HorizontalAlignment="Left" Margin="1,1,0,0" Padding="0" Grid.Row="1" TextWrapping="Wrap" Text="{Binding Unit}" VerticalAlignment="Top" Width="17" Grid.Column="5" Height="19"/>
-            <TextBlock HorizontalAlignment="Left" Margin="1,1,0,-1" Padding="0" Grid.Row="2" TextWrapping="Wrap" Text="{Binding Unit}" VerticalAlignment="Top" Width="17" Grid.Column="5" Height="19" />
-            <!--<Button Grid.Column="6" HorizontalAlignment="Left" Margin="22,0,-22,0" VerticalAlignment="Top" Width="17" RenderTransformOrigin="0.085,-0.108" Background="#FFB02929" Height="25" Grid.RowSpan="2" Command="{Binding MoveLeft}">
-                <Image Source="C:\Users\Klajdi\Documents\ControlSoftware\ControlSoftware\View\View\Resources\left_arrow.png"></Image>
-            </Button>
-            <Button Command="{Binding MoveRight}"  Grid.Column="6" HorizontalAlignment="Left" Height="28" Margin="22,11,-22,0" Grid.Row="1" Grid.RowSpan="2" VerticalAlignment="Top" Width="17" Background="#FF58CD15">
-                <Image Source="C:\Users\Klajdi\Documents\ControlSoftware\ControlSoftware\View\View\Resources\right_arrow.png"></Image>
-            </Button>-->
+            <NonFadingButton:NonFadingButton Grid.Column="3" Grid.Row="1" Grid.RowSpan="2" Background="{Binding ButtonColor}" Command="{Binding DigitalButton}"/>
+            <TextBlock TextAlignment="Left" Grid.Column="2" Margin="1" Grid.Row="1" TextWrapping="Wrap" Text="{Binding Unit}" Padding="0"/>
+
+            <steps:StepBasicView Grid.Column="0" Grid.ColumnSpan="3" Grid.Row="3"></steps:StepBasicView>
         </Grid>
     </Border>
 </UserControl>

--- a/View/View/Data/Steps/StepPythonView.xaml
+++ b/View/View/Data/Steps/StepPythonView.xaml
@@ -6,6 +6,7 @@
              xmlns:CustomElements="clr-namespace:CustomElements.SubmitTextBox;assembly=CustomElements"
              xmlns:CloseButton="clr-namespace:CustomElements.CloseButton;assembly=CustomElements"
              xmlns:nonFadingButton="clr-namespace:CustomElements.NonFadingButton;assembly=CustomElements"
+             xmlns:steps="clr-namespace:View.Data.Steps"
              mc:Ignorable="d"
              d:DesignHeight="80" d:DesignWidth="120" MinWidth="120" MaxWidth="120" >
 	<UserControl.Resources>
@@ -14,15 +15,15 @@
 	<Border BorderBrush="Gray" BorderThickness="1">
 		<Grid>
 			<Grid.RowDefinitions>
-				<RowDefinition Height="7*" />
-				<RowDefinition Height="8*" />
-				<RowDefinition Height="7*" />
-				<RowDefinition Height="7*" />
+				<RowDefinition Height="1*" />
+				<RowDefinition Height="1*" />
+				<RowDefinition Height="1*" />
+				<RowDefinition Height="1*" />
 			</Grid.RowDefinitions>
 			<Grid.ColumnDefinitions>
-				<ColumnDefinition Width="45*" />
-				<ColumnDefinition Width="65*" />
-				<ColumnDefinition Width="53*"/>
+				<ColumnDefinition Width="35" />
+				<ColumnDefinition Width="*" />
+				<ColumnDefinition Width="35"/>
 			</Grid.ColumnDefinitions>
 			<DockPanel Grid.ColumnSpan="3" VerticalAlignment="Stretch" HorizontalAlignment="Right" Width="118">
 				<nonFadingButton:NonFadingButton Width="20" Command="{Binding SetMessage}"  Background="{Binding SetMessageColor}" ToolTipService.IsEnabled="{Binding SetMessageShowTooltip}" ToolTip="{Binding SetMessageMessage}"/>
@@ -37,32 +38,19 @@
 			
 			<TextBlock Text="Dur.:" TextAlignment="Right" HorizontalAlignment="Stretch" Grid.Row="2"
                        VerticalAlignment="Stretch" Margin="1" Padding="0" ></TextBlock>
-			<CustomElements:SubmitTextBox VerticalContentAlignment="Center" HorizontalAlignment="Stretch" HorizontalContentAlignment="Right"
+            <CustomElements:SubmitTextBox VerticalContentAlignment="Center" HorizontalAlignment="Stretch" HorizontalContentAlignment="Right"
                                           VerticalAlignment="Stretch" Grid.Row="2" Grid.Column="1" Padding="0" Margin="1" Text="{Binding Duration, Mode=TwoWay}" Background="{Binding DurationColor, Mode=OneWay}" IsReadOnly="{Binding DurationIsReadOnly, Mode=OneWay}" ToolTipService.IsEnabled="{Binding DurationIsReadOnly, Mode=OneWay}" ToolTip="{Binding DurationVariableName, Mode=OneWay}" TextAlignment="Center">
-				<CustomElements:SubmitTextBox.ContextMenu>
-					<ContextMenu>
-						<MenuItem Name="userInputDurationMenu" Header="User Input" HorizontalAlignment="Left" Command="{Binding UserInputDuration}"/>
-						<MenuItem Name="staticMenu2" Header="Statics" HorizontalAlignment="Left" ItemsSource="{Binding staticNamesDuration}"/>
-						<MenuItem Name="iteratorMenu2" Header="Iterators" HorizontalAlignment="Left" ItemsSource="{Binding iteratorNamesDuration}"/>
-						<MenuItem Name="dynamicMenu2" Header="Dynamics" HorizontalAlignment="Left" ItemsSource="{Binding dynamicNamesDuration}"/>
-					</ContextMenu>
-				</CustomElements:SubmitTextBox.ContextMenu>
-			</CustomElements:SubmitTextBox>
-			<TextBlock Text="Start:" TextAlignment="Right" HorizontalAlignment="Stretch" Grid.Row="3"
-                       VerticalAlignment="Stretch" Padding="1" Margin="0" Foreground="Blue">
-				<TextBlock.ContextMenu>
-					<ContextMenu>
-						<MenuItem Header="Insert" Command="{Binding Insert}"></MenuItem>
-						<MenuItem Header="Move left" Command="{Binding MoveLeft}"></MenuItem>
-						<MenuItem Header="Move right"  Command="{Binding MoveRight}"></MenuItem>
-					</ContextMenu>
-				</TextBlock.ContextMenu>
-			</TextBlock>
-			<TextBox TextAlignment="Center" HorizontalAlignment="Stretch" Grid.Row="3" Grid.Column="1" Padding="0"
-                       Margin="1,1,1,0" Height="17" Text="{Binding StartTime, Mode=OneWay}" Background="LightGray" IsReadOnly="True"/>
-
-			<TextBlock TextAlignment="Left" Grid.Column="2" Margin="1" Grid.Row="2" TextWrapping="Wrap" Text="{Binding Unit}" Padding="0"/>
-			<TextBlock TextAlignment="Left" Grid.Column="2" Margin="1" Grid.Row="3" TextWrapping="Wrap" Text="{Binding Unit}" Padding="0"/>
+                <CustomElements:SubmitTextBox.ContextMenu>
+                    <ContextMenu>
+                        <MenuItem Name="userInputDurationMenu" Header="User Input" HorizontalAlignment="Left" Command="{Binding UserInputDuration}"/>
+                        <MenuItem Name="staticMenu2" Header="Statics" HorizontalAlignment="Left" ItemsSource="{Binding staticNamesDuration}"/>
+                        <MenuItem Name="iteratorMenu2" Header="Iterators" HorizontalAlignment="Left" ItemsSource="{Binding iteratorNamesDuration}"/>
+                        <MenuItem Name="dynamicMenu2" Header="Dynamics" HorizontalAlignment="Left" ItemsSource="{Binding dynamicNamesDuration}"/>
+                    </ContextMenu>
+                </CustomElements:SubmitTextBox.ContextMenu>
+            </CustomElements:SubmitTextBox>
+            <TextBlock TextAlignment="Left" Grid.Column="2" Margin="1" Grid.Row="2" TextWrapping="Wrap" Text="{Binding Unit}" Padding="0"/>
+            <steps:StepBasicView Grid.Column="0" Grid.ColumnSpan="3" Grid.Row="3"></steps:StepBasicView>
 		</Grid>
 	</Border>
 </UserControl>

--- a/View/View/Helper/Utilities.cs
+++ b/View/View/Helper/Utilities.cs
@@ -107,5 +107,21 @@ namespace View.Helper
                     SystemParameters.MinimumHorizontalDragDistance ||
                     Math.Abs(currentPosition.Y - initialMousePosition.Y) >= SystemParameters.MinimumVerticalDragDistance);
         }
+
+        public static T FindParentByType<T>(DependencyObject child) where T : DependencyObject
+        {
+            //get parent item
+            DependencyObject parentObject = VisualTreeHelper.GetParent(child);
+
+            //we've reached the end of the tree
+            if (parentObject == null) return null;
+
+            //check if the parent matches the type we're looking for
+            T parent = parentObject as T;
+            if (parent != null)
+                return parent;
+            else
+                return FindParentByType<T>(parentObject);
+        }
     }
 }

--- a/View/View/Helper/Utilities.cs
+++ b/View/View/Helper/Utilities.cs
@@ -42,10 +42,10 @@ namespace View.Helper
                 {
                     itemsControl.Items.Insert(insertionIndex, itemToInsert);
                 }
-                    // Is the ItemsSource IList or IList<T>? If so, insert the dragged item in the list.
+                // Is the ItemsSource IList or IList<T>? If so, insert the dragged item in the list.
                 else if (itemsSource is IList)
                 {
-                    ((IList) itemsSource).Insert(insertionIndex, itemToInsert);
+                    ((IList)itemsSource).Insert(insertionIndex, itemToInsert);
                 }
                 else
                 {
@@ -53,7 +53,7 @@ namespace View.Helper
                     Type genericIListType = type.GetInterface("IList`1");
                     if (genericIListType != null)
                     {
-                        type.GetMethod("Insert").Invoke(itemsSource, new[] {insertionIndex, itemToInsert});
+                        type.GetMethod("Insert").Invoke(itemsSource, new[] { insertionIndex, itemToInsert });
                     }
                 }
             }
@@ -73,10 +73,10 @@ namespace View.Helper
                     {
                         itemsControl.Items.RemoveAt(indexToBeRemoved);
                     }
-                        // Is the ItemsSource IList or IList<T>? If so, remove the item from the list.
+                    // Is the ItemsSource IList or IList<T>? If so, remove the item from the list.
                     else if (itemsSource is IList)
                     {
-                        ((IList) itemsSource).RemoveAt(indexToBeRemoved);
+                        ((IList)itemsSource).RemoveAt(indexToBeRemoved);
                     }
                     else
                     {
@@ -84,7 +84,7 @@ namespace View.Helper
                         Type genericIListType = type.GetInterface("IList`1");
                         if (genericIListType != null)
                         {
-                            type.GetMethod("RemoveAt").Invoke(itemsSource, new object[] {indexToBeRemoved});
+                            type.GetMethod("RemoveAt").Invoke(itemsSource, new object[] { indexToBeRemoved });
                         }
                     }
                 }
@@ -96,9 +96,9 @@ namespace View.Helper
         {
             if (hasVerticalOrientation)
             {
-                return clickedPoint.Y < container.ActualHeight/2;
+                return clickedPoint.Y < container.ActualHeight / 2;
             }
-            return clickedPoint.X < container.ActualWidth/2;
+            return clickedPoint.X < container.ActualWidth / 2;
         }
 
         public static bool IsMovementBigEnough(Point initialMousePosition, Point currentPosition)

--- a/View/View/Variables/VariableTypes/VariableBasicView.xaml
+++ b/View/View/Variables/VariableTypes/VariableBasicView.xaml
@@ -3,7 +3,6 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-			 xmlns:sys="clr-namespace:System;assembly=mscorlib"
              xmlns:SubmitTextBox="clr-namespace:CustomElements.SubmitTextBox;assembly=CustomElements" mc:Ignorable="d" 
              d:DesignHeight="28" d:DesignWidth="200">
 	<Grid ToolTip="{Binding UsagesAsString}">

--- a/View/View/Variables/VariableTypes/VariableBasicView.xaml
+++ b/View/View/Variables/VariableTypes/VariableBasicView.xaml
@@ -9,7 +9,7 @@
 
 
 
-        <SubmitTextBox:SubmitTextBox Name="VariableName" Text="{Binding VariableName, Mode=TwoWay}" PreviewKeyDown="VariableName_PreviewKeyDown" Background="{Binding VariableUsage, Mode=OneWay}">
+        <SubmitTextBox:SubmitTextBox Name="VariableName" Text="{Binding VariableName, Mode=TwoWay}" Background="{Binding VariableUsage, Mode=OneWay}">
 			<SubmitTextBox:SubmitTextBox.ContextMenu>
 				<ContextMenu>
 					<MenuItem Name="Static" Header="Static" Command="{Binding SwitchToStatic}"></MenuItem>

--- a/View/View/Variables/VariableTypes/VariableBasicView.xaml.cs
+++ b/View/View/Variables/VariableTypes/VariableBasicView.xaml.cs
@@ -21,14 +21,18 @@ namespace View.Variables.VariableTypes
             var realSender = (SubmitTextBox)sender;
             var dataContext = (VariableController)realSender.DataContext;
 
-            if (e.Key == Key.Up)
+            if (Keyboard.Modifiers == ModifierKeys.Control)
             {
-                dataContext.moveUp(dataContext);
-                e.Handled = true;
-            } else if (e.Key == Key.Down)
-            {
-                dataContext.moveDown(dataContext);
-                e.Handled = true;
+                if (e.Key == Key.Up)
+                {
+                    dataContext.moveUp(dataContext);
+                    e.Handled = true;
+                }
+                else if (e.Key == Key.Down)
+                {
+                    dataContext.moveDown(dataContext);
+                    e.Handled = true;
+                }
             }
         }
     }

--- a/View/View/Variables/VariableTypes/VariableBasicView.xaml.cs
+++ b/View/View/Variables/VariableTypes/VariableBasicView.xaml.cs
@@ -16,24 +16,5 @@ namespace View.Variables.VariableTypes
             InitializeComponent();
         }
 
-        private void VariableName_PreviewKeyDown(object sender, KeyEventArgs e)
-        {
-            var realSender = (SubmitTextBox)sender;
-            var dataContext = (VariableController)realSender.DataContext;
-
-            if (Keyboard.Modifiers == ModifierKeys.Control)
-            {
-                if (e.Key == Key.Up)
-                {
-                    dataContext.moveUp(dataContext);
-                    e.Handled = true;
-                }
-                else if (e.Key == Key.Down)
-                {
-                    dataContext.moveDown(dataContext);
-                    e.Handled = true;
-                }
-            }
-        }
     }
 }

--- a/View/View/Variables/VariableTypes/VariableDynamicView.xaml
+++ b/View/View/Variables/VariableTypes/VariableDynamicView.xaml
@@ -5,7 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:SubmitTextBox="clr-namespace:CustomElements.SubmitTextBox;assembly=CustomElements"
              xmlns:VariableTypes="clr-namespace:View.Variables.VariableTypes" mc:Ignorable="d" 
-             d:DesignHeight="300" d:DesignWidth="200">
+             d:DesignHeight="300" d:DesignWidth="200" PreviewMouseDown="UserControl_MouseDown">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="*"/>
@@ -16,7 +16,7 @@
             <ColumnDefinition Width="70*"></ColumnDefinition>
         </Grid.ColumnDefinitions>
         <VariableTypes:VariableBasicView Grid.Column ="0"></VariableTypes:VariableBasicView>
-        <SubmitTextBox:SubmitTextBox Grid.Column="1" Name="VariableValue" Text="{Binding VariableValue, Mode=TwoWay}"></SubmitTextBox:SubmitTextBox>
+        <SubmitTextBox:SubmitTextBox Grid.Column="1" Name="VariableValue" Text="{Binding VariableValue, Mode=TwoWay}" ></SubmitTextBox:SubmitTextBox>
         <SubmitTextBox:SubmitTextBox Grid.ColumnSpan="2" Grid.Row="1" Name="VariableCode" Text="{Binding VariableCode, Mode=TwoWay}" TextWrapping="Wrap" VerticalScrollBarVisibility="Visible" AcceptsReturn="True"></SubmitTextBox:SubmitTextBox>
     </Grid>
 </UserControl>

--- a/View/View/Variables/VariableTypes/VariableDynamicView.xaml.cs
+++ b/View/View/Variables/VariableTypes/VariableDynamicView.xaml.cs
@@ -2,6 +2,8 @@
 using System;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Media;
+using View.Helper;
 
 namespace View.Variables.VariableTypes
 {
@@ -13,6 +15,12 @@ namespace View.Variables.VariableTypes
         public VariableDynamicView()
         {
             InitializeComponent();
+        }
+
+        private void UserControl_MouseDown(object sender, MouseButtonEventArgs e)
+        {
+            ListBoxItem item = Utilities.FindParentByType<ListBoxItem>(this);
+            item.IsSelected = true;
         }
     }
 }

--- a/View/View/Variables/VariableTypes/VariableIteratorView.xaml
+++ b/View/View/Variables/VariableTypes/VariableIteratorView.xaml
@@ -5,7 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:VariableTypes="clr-namespace:View.Variables.VariableTypes"
              xmlns:SubmitTextBox="clr-namespace:CustomElements.SubmitTextBox;assembly=CustomElements" mc:Ignorable="d" 
-             d:DesignHeight="300" d:DesignWidth="340">
+             d:DesignHeight="300" d:DesignWidth="340" PreviewMouseDown="UserControl_PreviewMouseDown">
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="130*"></ColumnDefinition>

--- a/View/View/Variables/VariableTypes/VariableIteratorView.xaml.cs
+++ b/View/View/Variables/VariableTypes/VariableIteratorView.xaml.cs
@@ -38,5 +38,11 @@ namespace View.Variables.VariableTypes
             catch
             { }
         }
+
+        private void UserControl_MouseDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            ListBoxItem item = Utilities.FindParentByType<ListBoxItem>(this);
+            item.IsSelected = true;
+        }
     }
 }

--- a/View/View/Variables/VariableTypes/VariableIteratorView.xaml.cs
+++ b/View/View/Variables/VariableTypes/VariableIteratorView.xaml.cs
@@ -2,6 +2,7 @@
 using System.Windows;
 using System.Windows.Controls;
 using Controller.Variables;
+using View.Helper;
 
 namespace View.Variables.VariableTypes
 {
@@ -39,7 +40,8 @@ namespace View.Variables.VariableTypes
             { }
         }
 
-        private void UserControl_MouseDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
+
+        private void UserControl_PreviewMouseDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
             ListBoxItem item = Utilities.FindParentByType<ListBoxItem>(this);
             item.IsSelected = true;

--- a/View/View/Variables/VariablesView.xaml
+++ b/View/View/Variables/VariablesView.xaml
@@ -8,94 +8,94 @@
 		xmlns:diag="clr-namespace:System.Diagnostics;assembly=WindowsBase"
 		xmlns:Control="clr-namespace:View.Control"
         ShowInTaskbar="False" Name="theWindow">
-	<Window.Resources>
-		<ResourceDictionary Source="VariablesResources.xaml" />
-		
-		
-	</Window.Resources>
-	<Grid>
-		<Grid.RowDefinitions>
-			<RowDefinition Height="*"></RowDefinition>
-			<RowDefinition Height="28"></RowDefinition>
-		</Grid.RowDefinitions>
-		<Grid Grid.Row="0">
-			<!--  PreviewMouseMove="VariablesControl_PreviewMouseMove">-->
-			<Grid.ColumnDefinitions>
-				<ColumnDefinition Width="200*"></ColumnDefinition>
-				<ColumnDefinition Width="180*"></ColumnDefinition>
-				<ColumnDefinition Width="200*"></ColumnDefinition>
-			</Grid.ColumnDefinitions>
-			<Grid.RowDefinitions>
-				<RowDefinition Height="28"></RowDefinition>
-				<RowDefinition Height="23"></RowDefinition>
-				<RowDefinition Height="*"></RowDefinition>
-				<RowDefinition Height="25"></RowDefinition>
-			</Grid.RowDefinitions>
-			<Grid.Resources>
-				<DataTemplate x:Key="WindowsTemplate">
-					<Control:WindowsTemplate />
-				</DataTemplate>
-			</Grid.Resources>
-			<ListBox Grid.Row="0" Grid.ColumnSpan="3" IsSynchronizedWithCurrentItem="True" ItemsSource="{Binding WindowsList, UpdateSourceTrigger=PropertyChanged}" ItemTemplate="{StaticResource WindowsTemplate}" Name="WindowsListBox" HorizontalContentAlignment="Stretch">
-				<ListBox.ItemsPanel>
-					<ItemsPanelTemplate>
-						<StackPanel Orientation="Horizontal"/>
-					</ItemsPanelTemplate>
-				</ListBox.ItemsPanel>
-			</ListBox>
-			
-			<Button Name="addStatic" Grid.Row="3" Grid.Column="0" Command="{Binding AddStatic}">Add Static</Button>
-			<Grid Grid.Row="1" Grid.Column="0">
-				<Grid.ColumnDefinitions>
-					<ColumnDefinition Width="50*"></ColumnDefinition>
-					<ColumnDefinition Width="50*"></ColumnDefinition>
-				</Grid.ColumnDefinitions>
-				<TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Column="0">Name</TextBlock>
-				<TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Column="1">Value</TextBlock>
-			</Grid>
-			<ListBox IsSynchronizedWithCurrentItem="True" ItemsSource="{Binding Source={StaticResource collectionViewSource}, UpdateSourceTrigger=PropertyChanged}" ItemTemplateSelector="{StaticResource myDataTemplateSelector}" Name="VariablesStaticsControl" Grid.Row="2" Grid.Column="0" HorizontalContentAlignment="Stretch">
-				<ListBox.GroupStyle>
-					<GroupStyle ContainerStyle="{StaticResource ListBoxStyle}"/>
-				</ListBox.GroupStyle>
-				<!--  PreviewMouseLeftButtonDown="VariablesControl_PreviewMouseLeftButtonDown" PreviewMouseLeftButtonUp="VariablesControl_PreviewMouseLeftButtonUp">-->
-				<ListBox.ItemContainerStyle>
-					<Style>
-						<Setter Property="FrameworkElement.Margin" Value="0,0,0,5"/>
-					</Style>
-				</ListBox.ItemContainerStyle>
-				<ListBox.ItemsPanel>
-					<ItemsPanelTemplate>
+    <Window.Resources>
+        <ResourceDictionary Source="VariablesResources.xaml" />
 
-						<!--<UniformGrid Columns="3" VerticalAlignment="Top" />-->
-						<WrapPanel Orientation="Vertical" DataContext="{Binding ElementName=theWindow, Path=DataContext}" MaxHeight="{Binding StaticGroupHeight}" ItemWidth="215" />
-					</ItemsPanelTemplate>
-				</ListBox.ItemsPanel>
-			</ListBox>
 
-			<Button Name="addIterator" Grid.Row="3" Grid.Column="1" Command="{Binding AddIterator}">Add Iterator</Button>
-			<Grid Grid.Row="1" Grid.Column="1">
-				<Grid.ColumnDefinitions>
-					<ColumnDefinition Width="130*"></ColumnDefinition>
-					<ColumnDefinition Width="50*"></ColumnDefinition>
-					<ColumnDefinition Width="50*"></ColumnDefinition>
-					<ColumnDefinition Width="50*"></ColumnDefinition>
-					<ColumnDefinition Width="50*"></ColumnDefinition>
-				</Grid.ColumnDefinitions>
-				<TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Column="0">Name</TextBlock>
-				<TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Column="1">Curr.</TextBlock>
-				<TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Column="2">Start</TextBlock>
-				<TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Column="3">Stop</TextBlock>
-				<TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Column="4">Step</TextBlock>
-			</Grid>
-			<ListBox IsSynchronizedWithCurrentItem="True" ItemsSource="{Binding VariablesIterator, UpdateSourceTrigger=PropertyChanged}" ItemTemplate="{StaticResource VariableIteratorTemplate}" Name="VariablesIteratorsControl" Grid.Row="2" Grid.Column="1" HorizontalContentAlignment="Stretch">
-				<!-- PreviewMouseLeftButtonDown="VariablesControl_PreviewMouseLeftButtonDown" PreviewMouseLeftButtonUp="VariablesControl_PreviewMouseLeftButtonUp">-->
-				<ListBox.ItemContainerStyle>
-					<Style>
-						<Setter Property="FrameworkElement.Margin" Value="0,0,0,5"/>
-					</Style>
-				</ListBox.ItemContainerStyle>
-			</ListBox>
-			<!---->
+    </Window.Resources>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"></RowDefinition>
+            <RowDefinition Height="28"></RowDefinition>
+        </Grid.RowDefinitions>
+        <Grid Grid.Row="0">
+            <!--  PreviewMouseMove="VariablesControl_PreviewMouseMove">-->
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="200*"></ColumnDefinition>
+                <ColumnDefinition Width="180*"></ColumnDefinition>
+                <ColumnDefinition Width="200*"></ColumnDefinition>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="28"></RowDefinition>
+                <RowDefinition Height="23"></RowDefinition>
+                <RowDefinition Height="*"></RowDefinition>
+                <RowDefinition Height="25"></RowDefinition>
+            </Grid.RowDefinitions>
+            <Grid.Resources>
+                <DataTemplate x:Key="WindowsTemplate">
+                    <Control:WindowsTemplate />
+                </DataTemplate>
+            </Grid.Resources>
+            <ListBox Grid.Row="0" Grid.ColumnSpan="3" IsSynchronizedWithCurrentItem="True" ItemsSource="{Binding WindowsList, UpdateSourceTrigger=PropertyChanged}" ItemTemplate="{StaticResource WindowsTemplate}" Name="WindowsListBox" HorizontalContentAlignment="Stretch">
+                <ListBox.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Orientation="Horizontal"/>
+                    </ItemsPanelTemplate>
+                </ListBox.ItemsPanel>
+            </ListBox>
+
+            <Button Name="addStatic" Grid.Row="3" Grid.Column="0" Command="{Binding AddStatic}">Add Static</Button>
+            <Grid Grid.Row="1" Grid.Column="0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="50*"></ColumnDefinition>
+                    <ColumnDefinition Width="50*"></ColumnDefinition>
+                </Grid.ColumnDefinitions>
+                <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Column="0">Name</TextBlock>
+                <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Column="1">Value</TextBlock>
+            </Grid>
+            <ListBox IsSynchronizedWithCurrentItem="True" ItemsSource="{Binding Source={StaticResource collectionViewSource}, UpdateSourceTrigger=PropertyChanged}" ItemTemplateSelector="{StaticResource myDataTemplateSelector}" Name="VariablesStaticsControl" Grid.Row="2" Grid.Column="0" HorizontalContentAlignment="Stretch">
+                <ListBox.GroupStyle>
+                    <GroupStyle ContainerStyle="{StaticResource ListBoxStyle}"/>
+                </ListBox.GroupStyle>
+                <!--  PreviewMouseLeftButtonDown="VariablesControl_PreviewMouseLeftButtonDown" PreviewMouseLeftButtonUp="VariablesControl_PreviewMouseLeftButtonUp">-->
+                <ListBox.ItemContainerStyle>
+                    <Style>
+                        <Setter Property="FrameworkElement.Margin" Value="0,0,0,5"/>
+                    </Style>
+                </ListBox.ItemContainerStyle>
+                <ListBox.ItemsPanel>
+                    <ItemsPanelTemplate>
+
+                        <!--<UniformGrid Columns="3" VerticalAlignment="Top" />-->
+                        <WrapPanel Orientation="Vertical" DataContext="{Binding ElementName=theWindow, Path=DataContext}" MaxHeight="{Binding StaticGroupHeight}" ItemWidth="215" />
+                    </ItemsPanelTemplate>
+                </ListBox.ItemsPanel>
+            </ListBox>
+
+            <Button Name="addIterator" Grid.Row="3" Grid.Column="1" Command="{Binding AddIterator}">Add Iterator</Button>
+            <Grid Grid.Row="1" Grid.Column="1">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="130*"></ColumnDefinition>
+                    <ColumnDefinition Width="50*"></ColumnDefinition>
+                    <ColumnDefinition Width="50*"></ColumnDefinition>
+                    <ColumnDefinition Width="50*"></ColumnDefinition>
+                    <ColumnDefinition Width="50*"></ColumnDefinition>
+                </Grid.ColumnDefinitions>
+                <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Column="0">Name</TextBlock>
+                <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Column="1">Curr.</TextBlock>
+                <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Column="2">Start</TextBlock>
+                <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Column="3">Stop</TextBlock>
+                <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Column="4">Step</TextBlock>
+            </Grid>
+            <ListBox IsSynchronizedWithCurrentItem="True" ItemsSource="{Binding VariablesIterator, UpdateSourceTrigger=PropertyChanged}" ItemTemplate="{StaticResource VariableIteratorTemplate}" Name="VariablesIteratorsControl" Grid.Row="2" Grid.Column="1" HorizontalContentAlignment="Stretch">
+                <!-- PreviewMouseLeftButtonDown="VariablesControl_PreviewMouseLeftButtonDown" PreviewMouseLeftButtonUp="VariablesControl_PreviewMouseLeftButtonUp">-->
+                <ListBox.ItemContainerStyle>
+                    <Style>
+                        <Setter Property="FrameworkElement.Margin" Value="0,0,0,5"/>
+                    </Style>
+                </ListBox.ItemContainerStyle>
+            </ListBox>
+            <!---->
 
             <Button Name="addDynamic" Grid.Row="3" Grid.Column="2" Command="{Binding AddDynamic}">Add Dynamic</Button>
             <Grid Grid.Row="1" Grid.Column="2">
@@ -108,23 +108,23 @@
             </Grid>
             <ListBox IsSynchronizedWithCurrentItem="True" ItemsSource="{Binding VariablesDynamic, UpdateSourceTrigger=PropertyChanged}" ItemTemplate="{StaticResource VariableDynamicTemplate}" Name="VariablesDynamicsControl" Grid.Row="2" Grid.Column="2" HorizontalContentAlignment="Stretch">
                 <!-- PreviewMouseLeftButtonDown="VariablesControl_PreviewMouseLeftButtonDown" PreviewMouseLeftButtonUp="VariablesControl_PreviewMouseLeftButtonUp"> -->
-			<ListBox.ItemContainerStyle>
-				<Style>
-					<Setter Property="FrameworkElement.Margin" Value="0,0,0,5"/>
-				</Style>
-			</ListBox.ItemContainerStyle>
-			</ListBox>
-		</Grid>
-		<Grid Grid.Row="1">
-			<Grid.ColumnDefinitions>
-				<ColumnDefinition Width="100"></ColumnDefinition>
-				<ColumnDefinition Width="100"></ColumnDefinition>
-				<ColumnDefinition Width="100"></ColumnDefinition>
-				<ColumnDefinition Width="100"></ColumnDefinition>
-			</Grid.ColumnDefinitions>
-			<Button Command="{Binding Evaluate}">Evaluate</Button>
-			<Button Command="{Binding Iterate}" Grid.Column="1">Iterate</Button>
-			<Button Command="{Binding Check}" Grid.Column="2">Check Usage</Button>
-		</Grid>
-	</Grid>
+            <ListBox.ItemContainerStyle>
+                <Style>
+                    <Setter Property="FrameworkElement.Margin" Value="0,0,0,5"/>
+                </Style>
+            </ListBox.ItemContainerStyle>
+            </ListBox>
+        </Grid>
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="100"></ColumnDefinition>
+                <ColumnDefinition Width="100"></ColumnDefinition>
+                <ColumnDefinition Width="100"></ColumnDefinition>
+                <ColumnDefinition Width="100"></ColumnDefinition>
+            </Grid.ColumnDefinitions>
+            <Button Command="{Binding Evaluate}">Evaluate</Button>
+            <Button Command="{Binding Iterate}" Grid.Column="1">Iterate</Button>
+            <Button Command="{Binding Check}" Grid.Column="2">Check Usage</Button>
+        </Grid>
+    </Grid>
 </Window>

--- a/View/View/Variables/VariablesView.xaml
+++ b/View/View/Variables/VariablesView.xaml
@@ -87,8 +87,8 @@
                 <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Column="3">Stop</TextBlock>
                 <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Column="4">Step</TextBlock>
             </Grid>
-            <ListBox IsSynchronizedWithCurrentItem="True" ItemsSource="{Binding VariablesIterator, UpdateSourceTrigger=PropertyChanged}" ItemTemplate="{StaticResource VariableIteratorTemplate}" Name="VariablesIteratorsControl" Grid.Row="2" Grid.Column="1" HorizontalContentAlignment="Stretch">
-                <!-- PreviewMouseLeftButtonDown="VariablesControl_PreviewMouseLeftButtonDown" PreviewMouseLeftButtonUp="VariablesControl_PreviewMouseLeftButtonUp">-->
+            <ListBox IsSynchronizedWithCurrentItem="True" ItemsSource="{Binding VariablesIterator, UpdateSourceTrigger=PropertyChanged}" ItemTemplate="{StaticResource VariableIteratorTemplate}" Name="VariablesIteratorsControl" Grid.Row="2" Grid.Column="1" HorizontalContentAlignment="Stretch" PreviewKeyDown="VariablesIteratorsControl_PreviewKeyDown">
+                
                 <ListBox.ItemContainerStyle>
                     <Style>
                         <Setter Property="FrameworkElement.Margin" Value="0,0,0,5"/>
@@ -106,7 +106,7 @@
                 <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Column="0">Name</TextBlock>
                 <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Grid.Column="1">Value</TextBlock>
             </Grid>
-            <ListBox IsSynchronizedWithCurrentItem="True" ItemsSource="{Binding VariablesDynamic, UpdateSourceTrigger=PropertyChanged}" ItemTemplate="{StaticResource VariableDynamicTemplate}" Name="VariablesDynamicsControl" Grid.Row="2" Grid.Column="2" HorizontalContentAlignment="Stretch">
+            <ListBox IsSynchronizedWithCurrentItem="True" ItemsSource="{Binding VariablesDynamic, UpdateSourceTrigger=PropertyChanged}" ItemTemplate="{StaticResource VariableDynamicTemplate}" Name="VariablesDynamicsControl" Grid.Row="2" Grid.Column="2" HorizontalContentAlignment="Stretch" PreviewKeyDown="VariablesDynamicsControl_PreviewKeyDown">
                 <!-- PreviewMouseLeftButtonDown="VariablesControl_PreviewMouseLeftButtonDown" PreviewMouseLeftButtonUp="VariablesControl_PreviewMouseLeftButtonUp"> -->
             <ListBox.ItemContainerStyle>
                 <Style>

--- a/View/View/Variables/VariablesView.xaml.cs
+++ b/View/View/Variables/VariablesView.xaml.cs
@@ -36,7 +36,7 @@ namespace View.Variables
         }
         #endregion
 
-        Controller.Variables.VariablesController _controller;
+        VariablesController _controller;
         public VariablesView(Controller.Variables.VariablesController controller)
             :this()
         {
@@ -187,6 +187,8 @@ namespace View.Variables
 
             return null;
         }
+
+
         #endregion
 
         //private bool dragging = false;

--- a/View/View/Variables/VariablesView.xaml.cs
+++ b/View/View/Variables/VariablesView.xaml.cs
@@ -7,20 +7,42 @@ using System.Windows.Media;
 using Communication;
 using System.Windows.Interop;
 using System.Runtime.InteropServices;
+using System.Windows.Input;
+
 namespace View.Variables
 {
+    public class TaskListDataTemplateSelector : DataTemplateSelector
+    {
+        public override DataTemplate
+            SelectTemplate(object item, DependencyObject container)
+        {
+            FrameworkElement element = container as FrameworkElement;
+
+            if (element != null && item != null && item is VariableController)
+            {
+                VariableController taskitem = item as VariableController;
+
+                //System.Console.Write("Iswhat: {0}\n", taskitem.isGroupHeader);
+                if (taskitem.IsGroupHeader == true)
+                    return
+                        element.FindResource("VariableStaticGroupHeaderTemplate") as DataTemplate;
+                else
+                    return
+                        element.FindResource("VariableStaticTemplate") as DataTemplate;
+            }
+
+            return null;
+        }
+    }
+
     /// <summary>
     /// Interaction logic for VariablesView.xaml
     /// </summary>
     public partial class VariablesView : Window
     {
         #region Disable Minimize Button
-        [DllImport("user32.dll")]
-        private static extern int GetWindowLong(IntPtr hWnd, int nIndex);
-        [DllImport("user32.dll")]
-        private static extern int SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
-
         private const int GWL_STYLE = -16;
+
         private const int WS_MINIMIZE = -131073;
 
         public VariablesView()
@@ -34,6 +56,11 @@ namespace View.Variables
 
             };
         }
+
+        [DllImport("user32.dll")]
+        private static extern int GetWindowLong(IntPtr hWnd, int nIndex);
+        [DllImport("user32.dll")]
+        private static extern int SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
         #endregion
 
         VariablesController _controller;
@@ -47,6 +74,12 @@ namespace View.Variables
             SizeSavedWindow.addToSizeSavedWindows(this);
         }
 
+        protected override void OnClosing(System.ComponentModel.CancelEventArgs e)
+        {
+            e.Cancel = true;
+            this.Hide();
+        }
+
         private void loseFocus(object sender, EventArgs e)
         {
             foreach (VariableController staticView in VariablesIteratorsControl.Items)
@@ -58,43 +91,7 @@ namespace View.Variables
             //Keyboard.ClearFocus();
         }
 
-        protected override void OnClosing(System.ComponentModel.CancelEventArgs e)
-        {
-            e.Cancel = true;
-            this.Hide();
-        }
-
         #region GetDataFromListBox(ListBox,Point)
-        private static object GetDataFromListBox(ListBox source, Point point)
-        {
-            UIElement element = source.InputHitTest(point) as UIElement;
-            if (element != null)
-            {
-                object data = DependencyProperty.UnsetValue;
-                while (data == DependencyProperty.UnsetValue)
-                {
-                    data = source.ItemContainerGenerator.ItemFromContainer(element);
-
-                    if (data == DependencyProperty.UnsetValue)
-                    {
-                        element = VisualTreeHelper.GetParent(element) as UIElement;
-                    }
-
-                    if (element == source)
-                    {
-                        return null;
-                    }
-                }
-
-                if (data != DependencyProperty.UnsetValue)
-                {
-                    return data;
-                }
-            }
-
-            return null;
-        }
-
         private static object GetDataFromGrid(Grid source, Point point)
         {
             UIElement element = source.InputHitTest(point) as UIElement;
@@ -139,7 +136,35 @@ namespace View.Variables
 
             return null;
         }
+        private static object GetDataFromListBox(ListBox source, Point point)
+        {
+            UIElement element = source.InputHitTest(point) as UIElement;
+            if (element != null)
+            {
+                object data = DependencyProperty.UnsetValue;
+                while (data == DependencyProperty.UnsetValue)
+                {
+                    data = source.ItemContainerGenerator.ItemFromContainer(element);
 
+                    if (data == DependencyProperty.UnsetValue)
+                    {
+                        element = VisualTreeHelper.GetParent(element) as UIElement;
+                    }
+
+                    if (element == source)
+                    {
+                        return null;
+                    }
+                }
+
+                if (data != DependencyProperty.UnsetValue)
+                {
+                    return data;
+                }
+            }
+
+            return null;
+        }
         private static object GetRegionFromGrid(Grid source, Point point)
         {
             UIElement element = source.InputHitTest(point) as UIElement;
@@ -187,103 +212,46 @@ namespace View.Variables
 
             return null;
         }
-
-
         #endregion
 
-        //private bool dragging = false;
-        //Controller.Variables.VariableController draggedItem;
-
-        /*private void VariablesControl_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        private static bool MoveVariableWithArrowsIfNecessary(VariableController controller, System.Windows.Input.KeyEventArgs e)
         {
-            ListBox parent = (ListBox)sender;
-            object data = GetDataFromListBox(parent, e.GetPosition(parent));
-            if (data != null && !((Controller.Variables.VariableController)data).VariableLocked)
+            if (Keyboard.Modifiers == ModifierKeys.Control)
             {
-                //DragDrop.DoDragDrop(parent, data, DragDropEffects.Move);
-                dragging = true;
-                draggedItem = (Controller.Variables.VariableController)data;
-                //System.Console.Write("Drag: {0}\n", draggedItem.VariableName);
-            }
-            base.OnPreviewMouseLeftButtonDown(e);
-        }*/
-
-        /*private void VariablesControl_PreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
-        {
-            dragging = false;
-            this.Cursor = Cursors.Arrow;
-            base.OnPreviewMouseLeftButtonUp(e);
-        }*/
-
-        /*private void VariablesControl_PreviewMouseMove(object sender, MouseEventArgs e)
-        {
-            if (dragging && e.LeftButton == MouseButtonState.Released)
-            {
-                dragging = false;
-                this.Cursor = Cursors.Arrow;
-            }
-            if (dragging && e.LeftButton == MouseButtonState.Pressed)
-            {
-                this.Cursor = Cursors.Hand;
-                Grid parent = (Grid)sender;
-                object data = GetDataFromGrid(parent, e.GetPosition(parent));
-                if (data != null && !((Controller.Variables.VariableController)data).VariableLocked)
+                if (e.Key == Key.Up)
                 {
-                    Controller.Variables.VariableController droppedItem = (Controller.Variables.VariableController)data;
-                    //System.Console.Write("Drag: {0}\n", droppedItem.VariableName);
-                    if (draggedItem != droppedItem)
-                    {
-                        _controller.DoDragDrop(draggedItem, droppedItem);
-                    }
+                    controller.moveUp(null);
+                    e.Handled = true;
+                    return true;
                 }
-                else
+                else if (e.Key == Key.Down)
                 {
-                    data = GetRegionFromGrid(parent, e.GetPosition(parent));
-                    if (data != null)
-                    {
-
-                        if (data.GetType().Equals(typeof(CustomElements.VariableType)))
-                        {
-                            CustomElements.VariableType newType = (CustomElements.VariableType)data;
-                            //System.Console.Write("Drag 0\n");
-                            if (newType == CustomElements.VariableType.VariableTypeIterator && _controller.IsIteratorsLocked())
-                            { }
-                            else
-                            {
-                                _controller.DoDragDropRegion(draggedItem, newType);
-                            }
-                        }
-                    }
+                    controller.moveDown(null);
+                    e.Handled = true;
+                    return true;
                 }
             }
-            base.OnPreviewMouseMove(e);
-        }*/
-    }
 
-
-
-
-    public class TaskListDataTemplateSelector : DataTemplateSelector
-    {
-        public override DataTemplate
-            SelectTemplate(object item, DependencyObject container)
-        {
-            FrameworkElement element = container as FrameworkElement;
-
-            if (element != null && item != null && item is VariableController)
-            {
-                VariableController taskitem = item as VariableController;
-
-                //System.Console.Write("Iswhat: {0}\n", taskitem.isGroupHeader);
-                if (taskitem.IsGroupHeader == true)
-                    return
-                        element.FindResource("VariableStaticGroupHeaderTemplate") as DataTemplate;
-                else
-                    return
-                        element.FindResource("VariableStaticTemplate") as DataTemplate;
-            }
-
-            return null;
+            return false;
         }
+
+        private void VariablesDynamicsControl_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (VariablesDynamicsControl.SelectedIndex >= 0)
+            {
+                VariableController selectedController = (VariableController)VariablesDynamicsControl.SelectedItem;
+                MoveVariableWithArrowsIfNecessary(selectedController, e);
+            }
+        }
+
+        private void VariablesIteratorsControl_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (VariablesIteratorsControl.SelectedIndex >= 0)
+            {
+                VariableController selectedController = (VariableController)VariablesIteratorsControl.SelectedItem;
+                MoveVariableWithArrowsIfNecessary(selectedController, e);
+            }
+        }
+
     }
 }

--- a/View/View/View.csproj
+++ b/View/View/View.csproj
@@ -152,6 +152,9 @@
     <Compile Include="Data\Steps\SetMessageWindowView.xaml.cs">
       <DependentUpon>SetMessageWindowView.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Data\Steps\StepBasicView.xaml.cs">
+      <DependentUpon>StepBasicView.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Data\Steps\StepPythonSetScriptView.xaml.cs">
       <DependentUpon>StepPythonSetScriptView.xaml</DependentUpon>
     </Compile>
@@ -300,6 +303,10 @@
     <Page Include="Data\Steps\SetMessageWindowView.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Data\Steps\StepBasicView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Data\Steps\StepPythonSetScriptView.xaml">
       <SubType>Designer</SubType>


### PR DESCRIPTION
- Use `ctrl + left arrow` or `ctrl + right arrow` to move steps to the left or the right.
- Selection is maintained so that further movements can be made without using the mouse.
![image](https://user-images.githubusercontent.com/28387669/80888553-b4032000-8cbe-11ea-877f-691963a56848.png)

![image](https://user-images.githubusercontent.com/28387669/80890245-296ef080-8cbf-11ea-9b21-7f271283c852.png)
- Use ``ctrl + up arrow`` or ``ctrl + down arrow`` to move iterator or dynamic variables up and down. 
- Selection of variable is maintained after movement so further movements can be made without using the mouse.
![image](https://user-images.githubusercontent.com/28387669/80890973-52908080-8cc1-11ea-9e97-6aba73293992.png)
- Demanding the ``ctrl`` ensures no accidental movements happen.
- Fixes feature request #5 

