### PR TITLE
Fix Output Replication Bug

### DIFF
--- a/Controller/Controller/MainWindow/MainWindowController.cs
+++ b/Controller/Controller/MainWindow/MainWindowController.cs
@@ -132,7 +132,7 @@ namespace Controller.MainWindow
                 double waitTime = (double)((DecimalSetting)ProfilesManager.GetInstance().ActiveProfile.GetSettingByName(SettingNames.CONSTANT_WAIT_TIME)).Value;
 
                 return
-                    Math.Round((_buffer.Duration * TimesToReplicateOutput + waitTime) * OutputHandler.NumberOfIterations);
+                    Math.Round((_buffer.DurationSeconds + waitTime) * OutputHandler.NumberOfIterations);
             }
         }
 
@@ -428,7 +428,7 @@ namespace Controller.MainWindow
             get
             {
                 decimal waitTime = ((DecimalSetting)ProfilesManager.GetInstance().ActiveProfile.GetSettingByName(SettingNames.CONSTANT_WAIT_TIME)).Value;
-                return "(" + waitTime + ") + " + Math.Round(_buffer.Duration * TimesToReplicateOutput).ToString();
+                return "(" + waitTime + ") + " + Math.Round(_buffer.DurationSeconds);
             }
         }
 

--- a/Controller/Controller/MainWindow/MainWindowController.cs
+++ b/Controller/Controller/MainWindow/MainWindowController.cs
@@ -481,6 +481,7 @@ namespace Controller.MainWindow
             {
                 GetRootController().TimesToReplicateOutput = value;
                 //OnPropertyChanged("TimesToReplicateOutput");
+                GetRootController().CopyToBuffer();
                 GetRootController().EnableCopyToBufferAndCopyChanges();
             }
 

--- a/Controller/Controller/MainWindow/MeasurementRoutine/MeasurementRoutineSampleScriptController.cs
+++ b/Controller/Controller/MainWindow/MeasurementRoutine/MeasurementRoutineSampleScriptController.cs
@@ -81,7 +81,7 @@ namespace Controller.MainWindow.MeasurementRoutine
                 //       "routine_array.Add(0)\n" +
                 //       "routine_array.Add(0)";
                 return "import sys\n"+
-                       "sys.path.append(r'C:\\Program Files (x86)\\IronPython 2.7\\Lib') # to import external libraries\n" +
+                       "sys.path.append(r'C:\\Program Files\\IronPython 2.7\\Lib') # to import external libraries\n" +
                        "import os\n" +
                        "n = -1 # initialize the counter\n" + // this is intialized by -1 because in the sample script we want to run the primary model 5 times before switching to the secondary mode.
                       "# create some cells in the routine array\n" +

--- a/Controller/Controller/MainWindow/MeasurementRoutine/MeasurementRoutineScriptController.cs
+++ b/Controller/Controller/MainWindow/MeasurementRoutine/MeasurementRoutineScriptController.cs
@@ -422,13 +422,13 @@ namespace Controller.MainWindow.MeasurementRoutine
         //Ebaa 29.05.2018
         private void ShowExecutionSteps(object parameter)
         {
-            String stepsInfo="The main execution steps of the measurement routine are as follows:"+"\n"+
-                "1- Execute the repetitive python script and decide which model to be loaded next."+"\n" +
-                "2- Increase current model counters."+"\n" +
-                "3- Load the next model to be executed."+ "\n"+ 
-                "4- Save the next model to be executed to the database." +"\n"+
-                "5- Execute the model that was loaded before.";
-            MessageBox.Show(stepsInfo);
+            String stepsInfo="The execution steps of a measurement routine:\n\n"+
+                "1- Execute the repetitive python script and decide which model to be loaded next.\n"+
+                "2- Increase current model iterators.\n"+
+                "3- Load the next model.\n"+  
+                "4- Save the next model to the database.\n" +
+                "5- Execute the loaded next model.";
+            MessageBox.Show(stepsInfo, "Execution Steps Description", MessageBoxButton.OK, MessageBoxImage.Information);
         }
 
 
@@ -460,6 +460,7 @@ namespace Controller.MainWindow.MeasurementRoutine
             }
             else
             {
+                MessageBox.Show("The script successfully passed validation!", "Script OK", MessageBoxButton.OK, MessageBoxImage.Information);
                 this.requiresCodeCheck = false;
             }
         }

--- a/Controller/Controller/MainWindow/MeasurementRoutine/MeasurementRoutineScriptController.cs
+++ b/Controller/Controller/MainWindow/MeasurementRoutine/MeasurementRoutineScriptController.cs
@@ -56,9 +56,9 @@ namespace Controller.MainWindow.MeasurementRoutine
             {
                 switch (VariableType)
                 {
-                    case VariableUsageDescriptor.VariableTypeEnum.Boolean:
+                    case VariableTypeEnum.Boolean:
                         return "Boolean";
-                    case VariableUsageDescriptor.VariableTypeEnum.Integer:
+                    case VariableTypeEnum.Integer:
                         return "Integer";
                     case VariableTypeEnum.String:
                         return "String";
@@ -448,6 +448,7 @@ namespace Controller.MainWindow.MeasurementRoutine
                     scriptToAnalyze = InitializationScript + "\n";
 
                 scriptToAnalyze += Script;
+
                 if (!MeasurementRoutineManager.ValidatePythonScript(scriptToAnalyze, out errorMessage, false))
                 {
                     result = errorMessage;

--- a/Controller/Controller/OutputVisualizer/OutputVisualizationWindowController.cs
+++ b/Controller/Controller/OutputVisualizer/OutputVisualizationWindowController.cs
@@ -185,9 +185,9 @@ namespace Controller.OutputVisualizer
             foreach (AbstractSequenceController sequence in sequeces)
             {
                 Color color = Color.FromArgb((byte)random.Next(0, 256), (byte)random.Next(0, 256), (byte)random.Next(0, 256), (byte)random.Next(0, 256));
-                string name = string.Format("{0} ({1})", ((TabController)sequence).Name, sequence.Index().ToString());
+                string name = $"{((TabController) sequence).Name} ({sequence.Index().ToString()})";
                 double startTime = sequence.ActualStartTime();
-                double duration = sequence.LongestDurationAllSequences();
+                double duration = sequence.LongestDurationAllSequences() * GetRootController().TimesToReplicateOutput;
 
                 VisualElement nameOfSequence = new VisualElement();
 
@@ -258,7 +258,7 @@ namespace Controller.OutputVisualizer
         /// <param name="channel">The checked channel to be displayed</param>
         private void AddDataToChannel(CTVItemViewModel channel)
         {
-            ChannelBasicController channelController = (ChannelBasicController)(channel as CheckableTVItemController).Item;
+            ChannelBasicController channelController = (ChannelBasicController)((CheckableTVItemController) channel).Item;
             string cardName = channelController.Parent.Parent.Model.Name;
             OutputVisualizerController ovc = GetControllerOfChannel(channel);
 
@@ -297,10 +297,10 @@ namespace Controller.OutputVisualizer
         }
 
         /// <summary>
-        /// Given a checked tree view element, reurns the corresponding channel visalization controller.
+        /// Given a checked tree view element, returns the corresponding channel visalization controller.
         /// </summary>
         /// <param name="channel">a checked tree view element</param>
-        /// <returns>the corresponding channel visalization controller</returns>
+        /// <returns>the corresponding channel visualization controller</returns>
         private OutputVisualizerController GetControllerOfChannel(CTVItemViewModel channel)
         {
             ChannelBasicController channelController = (ChannelBasicController)(channel as CheckableTVItemController).Item;
@@ -308,8 +308,7 @@ namespace Controller.OutputVisualizer
             string controllerName = cardName + "-" + channelController.ToString();
             // select the corresponding controller
             return AllControllers
-                .Where((controller) => controller.NameOfCardAndChannel.Equals(controllerName))
-                .First();
+                .First(controller => controller.NameOfCardAndChannel.Equals(controllerName));
         }
 
         /// <summary>

--- a/Controller/Controller/Root/RootController.cs
+++ b/Controller/Controller/Root/RootController.cs
@@ -56,7 +56,7 @@ namespace Controller.Root
         }
 
         /// <summary>
-        /// Unlock the buffer to allow one of the threads to acess it.
+        /// Unlock the buffer to allow one of the threads to access it.
         /// </summary>
         /// <param name="updateLock">The lock object.</param>
         public bool BulkUpdateEnd(object updateLock)
@@ -72,7 +72,7 @@ namespace Controller.Root
 
         }
         /// <summary>
-        /// reenables the CopyToBuffer function and triggers it once
+        /// Re-enables the CopyToBuffer function and triggers it once
         /// </summary>
         public void EnableCopyToBufferAndCopyChanges()
         {
@@ -106,7 +106,7 @@ namespace Controller.Root
                 if (_enableCopyToBuffer)
                 {
                     //Console.Write("copy to buffer\n");
-                    (_buffer as DoubleBuffer).Duration = Duration();
+                    ((DoubleBuffer) _buffer).Duration = Duration() * TimesToReplicateOutput;
                     _buffer.CopyData(Model, TimesToReplicateOutput);
                     _pendingChanges = false;
                     //System.Console.WriteLine("Duration: {0}\n", Duration());

--- a/Controller/Controller/Root/RootController.cs
+++ b/Controller/Controller/Root/RootController.cs
@@ -96,21 +96,17 @@ namespace Controller.Root
         /// </summary>
         public void CopyToBuffer()
         {
-
             ErrorCollector errorCollector = ErrorCollector.Instance;
             errorCollector.RemoveErrorsOfWindow(ErrorWindow.MainHardware);
+
             if (Model.Verify())
             {
                 //errorCollector.stopBlink();
 
                 if (_enableCopyToBuffer)
                 {
-                    //Console.Write("copy to buffer\n");
-                    ((DoubleBuffer) _buffer).Duration = Duration() * TimesToReplicateOutput;
                     _buffer.CopyData(Model, TimesToReplicateOutput);
                     _pendingChanges = false;
-                    //System.Console.WriteLine("Duration: {0}\n", Duration());
-
                 }
                 else
                 {

--- a/GeneratorUT/BasicStepUT.cs
+++ b/GeneratorUT/BasicStepUT.cs
@@ -9,7 +9,7 @@ using Model.Root;
 namespace GeneratorUT
 {
     [TestClass]
-    public class BasicStepUnitTest : ParentUT
+    public class BasicStepUT : ParentUT
     {
         [DataRow("Resources\\disabled-first-sequence.xml.gz", "Dy4thFloor")]
         [DataRow("Resources\\disabled-mid-sequence.xml.gz", "Dy4thFloor")]

--- a/GeneratorUT/DoubleBufferUT.cs
+++ b/GeneratorUT/DoubleBufferUT.cs
@@ -1,0 +1,40 @@
+﻿using System.Linq;
+using Buffer.Basic;
+using Communication.Interfaces.Generator;
+using Generator.Generator;
+using MainProject.Builders;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Model.Builder;
+using Model.Root;
+
+namespace GeneratorUT
+{
+    [TestClass]
+    public class DoubleBufferUT : ParentUT
+    {
+        [DataRow("Resources\\0.2ms.xml.gz", "Dy4thFloor")]
+        [DataRow("Resources\\0.0ms.xml.gz", "Dy4thFloor")]
+        [DataTestMethod]
+        public void TestRegularOutputDurationWithReplication(string modelName, string profileName)
+        {
+            const int timesToReplicate = 3;
+            RootModel model = base.LoadModel(modelName);
+            ModelBuilder modelBuilder = new ModelBuilder(); 
+            modelBuilder.Build();
+            DoubleBufferBuilder builder = new DoubleBufferBuilder();
+            builder.Build(model, modelBuilder.GetCardTypes());
+            DoubleBuffer buffer = builder.GetDoubleBuffer();
+            DataOutputGenerator outputGenerator = CreateOutputGenerator(modelName, profileName);
+            IModelOutput output = outputGenerator.Generate();
+
+            buffer.FinishedModelGeneration += (sender, args) =>
+            {
+                Assert.IsTrue(args.IsSuccessful);
+                Assert.IsTrue(DoubleEquals(output.OutputDurationMillis * timesToReplicate / 1000.0, buffer.DurationSeconds));
+            };
+
+            buffer.CopyData(model, timesToReplicate);
+            
+        }
+    }
+}

--- a/GeneratorUT/GeneratorUT.csproj
+++ b/GeneratorUT/GeneratorUT.csproj
@@ -70,6 +70,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DoubleBufferUT.cs" />
     <Compile Include="ModelOutputUT.cs" />
     <Compile Include="ParentUT.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
@@ -77,7 +78,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
-    <Compile Include="BasicStepUnitTest.cs" />
+    <Compile Include="BasicStepUT.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -121,6 +122,10 @@
     <ProjectReference Include="..\Generator\Generator\Generator.csproj">
       <Project>{618F796E-6ED6-4F5D-8BA9-08929DD46038}</Project>
       <Name>Generator</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\MainProject\MainProject.csproj">
+      <Project>{d702d6bc-3b82-46d9-9802-db767b9bc5d1}</Project>
+      <Name>MainProject</Name>
     </ProjectReference>
     <ProjectReference Include="..\Model\Model\Model.csproj">
       <Project>{8E3379F7-41FB-4A3B-B3EC-74451D7E9E6C}</Project>

--- a/GeneratorUT/ModelOutputUT.cs
+++ b/GeneratorUT/ModelOutputUT.cs
@@ -4,14 +4,12 @@ using Communication.Interfaces.Generator;
 using Generator.Cookbook;
 using Generator.Generator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Model.Data;
 using Model.Root;
-using System;
 
 namespace GeneratorUT
 {
     [TestClass]
-    public class ModelOutputUT: ParentUT
+    public class ModelOutputUT : ParentUT
     {
         [DataRow("Resources\\0.2ms.xml.gz", "Dy4thFloor")]
         [DataRow("Resources\\0.0ms.xml.gz", "Dy4thFloor")]
@@ -20,7 +18,6 @@ namespace GeneratorUT
         {
             DataOutputGenerator outputGenerator = CreateOutputGenerator(modelName, profileName);
             IModelOutput output = outputGenerator.Generate();
-
             Assert.IsTrue(DoubleEquals(outputGenerator.Duration() * 1000.0, output.OutputDurationMillis));
             output.ReplicateOutput(3);
             Assert.IsTrue(DoubleEquals(outputGenerator.Duration() * 1000.0 * 3, output.OutputDurationMillis));
@@ -41,16 +38,10 @@ namespace GeneratorUT
             OutputCompressor oc = new OutputCompressor(model.Data);
             oq.Process(output);
             oc.Process(output);
-            
+
             Assert.IsTrue(DoubleEquals(outputGenerator.Duration() * 1000.0, output.OutputDurationMillis));
             output.ReplicateOutput(3);
             Assert.IsTrue(DoubleEquals(outputGenerator.Duration() * 1000.0 * 3, output.OutputDurationMillis));
-        }
-
-        private bool DoubleEquals(double value1, double value2)
-        {
-            const double TOLERATED_DIFFERENCE = 1.0E-15;
-            return Math.Abs(value1 - value2) <= TOLERATED_DIFFERENCE;
         }
     }
 }

--- a/GeneratorUT/ParentUT.cs
+++ b/GeneratorUT/ParentUT.cs
@@ -1,4 +1,5 @@
-﻿using Controller.MainWindow;
+﻿using System;
+using Controller.MainWindow;
 using Generator.Cookbook;
 using Generator.Generator;
 using Model.Root;
@@ -13,8 +14,7 @@ namespace GeneratorUT
         {
             ProfilesManager profileManager = ProfilesManager.GetInstance();
             profileManager.ActiveProfile = profileManager.Profiles
-                .Where(prof => prof.Name == profileName)
-                .First();
+                .First(prof => prof.Name == profileName);
         }
         public RootModel LoadModel(string fileName)
         {         
@@ -28,6 +28,13 @@ namespace GeneratorUT
             RootModel model = LoadModel(modelName);
             GeneratorRecipe recipe = new GeneratorRecipe(new SequenceGroupGeneratorRecipe());
             return (DataOutputGenerator)recipe.Cook(model);
+        }
+
+
+        public static bool DoubleEquals(double value1, double value2)
+        {
+            const double TOLERATED_DIFFERENCE = 1.0E-15;
+            return Math.Abs(value1 - value2) <= TOLERATED_DIFFERENCE;
         }
     }
 }

--- a/MainProject/Builders/DoubleBufferBuilder.cs
+++ b/MainProject/Builders/DoubleBufferBuilder.cs
@@ -12,7 +12,7 @@ using Model.Settings;
 
 namespace MainProject.Builders
 {
-    class DoubleBufferBuilder
+    public class DoubleBufferBuilder
     {
         private DoubleBuffer doubleBuffer;
 
@@ -53,7 +53,7 @@ namespace MainProject.Builders
             HardwareManager hardwareManager = new HardwareManager(experiment);
 
             OutputHandler outputHandler = new OutputHandler(hardwareManager);
-            this.doubleBuffer = new DoubleBuffer(generatorRecipe, hardwareManager, outputHandler);
+            this.doubleBuffer = new DoubleBuffer(generatorRecipe, outputHandler);
         }
 
         public DoubleBuffer GetDoubleBuffer()

--- a/Model/Model/Builder/ModelBuilder.cs
+++ b/Model/Model/Builder/ModelBuilder.cs
@@ -35,7 +35,6 @@ namespace Model.Builder
         /// <remarks>The result of the building process can be accessed using the <see cref=" GetRootModel"/> method.</remarks>
         public void Build()
         {
-            Profile activeProfile = ProfilesManager.GetInstance().ActiveProfile;
             //Creating new RootModel
             RootModel model = new RootModel();
 


### PR DESCRIPTION
- Fixes a bug that prevents the output from being replicated using the `Times to Replicate` option.
- Ensures correct visualization of the replicated output.
- Simplifies handling of durations.
- Adds a unit test for replication in buffer.
- Fixes #17 
