### PR TITLE
Fix/issue 038 - Visual Appearance of Variables not Updating after Changing Their Type

### DIFF
--- a/Controller/Controller/Data/Steps/StepBasicController.cs
+++ b/Controller/Controller/Data/Steps/StepBasicController.cs
@@ -26,20 +26,13 @@ namespace Controller.Data.Steps
     public abstract class StepBasicController : AbstractStepController, INotifyPropertyChanged
     {
 
-        // ******************** Events ******************** 
-        // ************************************************
-        /// <summary>
-        /// Occurs when a property value changes.
-        /// </summary>
-        public event PropertyChangedEventHandler PropertyChanged;
-
         // ******************** Fields ******************** 
         // ************************************************
         /// <summary>
         /// The model of this step
         /// </summary>
         internal readonly StepBasicModel _model;
-       
+
         /// <summary>
         /// The controller for the channel that contains this step
         /// </summary>
@@ -74,19 +67,24 @@ namespace Controller.Data.Steps
             _model = model;
             RemoveItem = new RelayCommand(Remove);
             DigitalButton = new RelayCommand(SetDigitalValue);
-
             UserInputValue = new RelayCommand(SetUserInputValue);
             UserInputDuration = new RelayCommand(SetUserInputDuration);
             VariableInputValue = new RelayCommand(SetVariableInputValue);
             VariableInputDuration = new RelayCommand(SetVariableInputDuration);
-            Insert = new RelayCommand(DoInsert);
-            MoveLeft = new RelayCommand(DoMoveLeft);
-            MoveRight = new RelayCommand(DoMoveRight);
+            InsertCommand = new RelayCommand(DoInsert);
+            MoveLeftCommand = new RelayCommand(DoMoveLeft);
+            MoveRightCommand = new RelayCommand(DoMoveRight);
             SetMessage = new RelayCommand(DoSetMessage);
             KeyDownPressedCommand = new RelayCommand(OnPreviewKeyDown);
 
         }
 
+        // ******************** Events ******************** 
+        // ************************************************
+        /// <summary>
+        /// Occurs when a property value changes.
+        /// </summary>
+        public event PropertyChangedEventHandler PropertyChanged;
         // ******************* Properties **********************
         // *****************************************************
         /// <summary>
@@ -352,13 +350,14 @@ namespace Controller.Data.Steps
             }
         }
 
+
         /// <summary>
         /// Gets or sets the command that is triggered when the insert button is clicked
         /// </summary>
         /// <value>
         /// The insert command.
         /// </value>
-        public ICommand Insert { get; set; }
+        public ICommand InsertCommand { get; set; }
 
         /// <summary>
         /// Gets the names of all iterator variables which can be used as durations for steps
@@ -387,6 +386,10 @@ namespace Controller.Data.Steps
                 return ConstructVariableMenuItems(VariableInputValue, Variables.VariablesIterator);
             }
         }
+        /// <summary>
+        /// This command is triggered is triggered when the user presses a keyboard button while the control is in focus
+        /// </summary>
+        public ICommand KeyDownPressedCommand { private set; get; }
 
         /// <summary>
         /// Gets or sets the command that is triggered when the move left button is clicked
@@ -394,7 +397,7 @@ namespace Controller.Data.Steps
         /// <value>
         /// The move left command.
         /// </value>
-        public ICommand MoveLeft { get; private set; }
+        public ICommand MoveLeftCommand { get; private set; }
 
         /// <summary>
         /// Gets or sets the command that is triggered when the move right button is clicked
@@ -402,7 +405,7 @@ namespace Controller.Data.Steps
         /// <value>
         /// The move right command.
         /// </value>
-        public ICommand MoveRight { get; private set; }
+        public ICommand MoveRightCommand { get; private set; }
     
         /// <summary>
         /// Gets or sets the command that is triggered when the remove item button is clicked
@@ -419,43 +422,6 @@ namespace Controller.Data.Steps
         /// The set message command.
         /// </value>
         public ICommand SetMessage { get; private set; }
-
-        /// <summary>
-        /// Gets or sets the command that is triggered when the duration of the step is associated to a variable
-        /// </summary>
-        /// <value>
-        /// The variable input value command.
-        /// </value>
-        public ICommand VariableInputDuration { get; private set; }
-
-        /// <summary>
-        /// Gets or sets the command that is triggered when the value of the step is associated to a variable
-        /// </summary>
-        /// <value>
-        /// The variable input value command.
-        /// </value>
-        public ICommand VariableInputValue { get; private set; }
-
-        /// <summary>
-        /// Gets or sets the command that is triggered when the user sets the duration manually
-        /// </summary>
-        /// <value>
-        /// The duration of the user input command.
-        /// </value>
-        public ICommand UserInputDuration { get; private set; }
-
-        /// <summary>
-        /// Gets or sets the command that is triggered when the user sets the value manually
-        /// </summary>
-        /// <value>
-        /// The user input value command.
-        /// </value>
-        public ICommand UserInputValue { get; private set; }
-
-        /// <summary>
-        /// This command is triggered is triggered when the user presses a keyboard button while the control is in focus
-        /// </summary>
-        public ICommand KeyDownPressedCommand { private set; get; }
 
         /// <summary>
         /// Gets the color of the set message button.
@@ -577,6 +543,22 @@ namespace Controller.Data.Steps
         {
             get { return TimeSettingsInfo.GetInstance().TimeUnit; }
         }
+
+        /// <summary>
+        /// Gets or sets the command that is triggered when the user sets the duration manually
+        /// </summary>
+        /// <value>
+        /// The duration of the user input command.
+        /// </value>
+        public ICommand UserInputDuration { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the command that is triggered when the user sets the value manually
+        /// </summary>
+        /// <value>
+        /// The user input value command.
+        /// </value>
+        public ICommand UserInputValue { get; private set; }
 
         /// <summary>
         /// Gets or sets the value of the step
@@ -704,7 +686,22 @@ namespace Controller.Data.Steps
                 return GetValueVariableName();
             }
         }
-      
+
+        /// <summary>
+        /// Gets or sets the command that is triggered when the duration of the step is associated to a variable
+        /// </summary>
+        /// <value>
+        /// The variable input value command.
+        /// </value>
+        public ICommand VariableInputDuration { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the command that is triggered when the value of the step is associated to a variable
+        /// </summary>
+        /// <value>
+        /// The variable input value command.
+        /// </value>
+        public ICommand VariableInputValue { get; private set; }
         /// <summary>
         /// Gets the variables' controller.
         /// </summary>
@@ -934,11 +931,13 @@ namespace Controller.Data.Steps
             SetValueVariableName(variable.VariableName);
             ValueVariable = variable;
             Value = ValueVariable.VariableValue;
+
             if (null != this.PropertyChanged)
             {
                 PropertyChanged(this, new PropertyChangedEventArgs("ValueColor"));
                 PropertyChanged(this, new PropertyChangedEventArgs("ValueIsReadOnly"));
             }
+
             UpdateProperty("ValueVariableName");
         }
 
@@ -1268,8 +1267,8 @@ namespace Controller.Data.Steps
                 if (Math.Abs(GetValue()) < 0.001)
                     SetValue(1);
             }
-            UpdateProperty("ButtonColor");
 
+            UpdateProperty("ButtonColor");
         }
 
     }

--- a/Controller/Controller/Data/Steps/StepBasicController.cs
+++ b/Controller/Controller/Data/Steps/StepBasicController.cs
@@ -270,7 +270,7 @@ namespace Controller.Data.Steps
                 //System.Console.Write("Duration, Get\n");
                 if (_durationVariable == null && GetDurationVariableName() != null)
                 {
-                    if (GetDurationVariableName().Equals(VariableController.NOVARIABLE))
+                    if (GetDurationVariableName().Equals(VariableController.NO_VARIABLE))
                     {
 
                     }
@@ -653,7 +653,7 @@ namespace Controller.Data.Steps
                 //System.Console.Write("Value, Get\n");
                 if (_valueVariable == null && GetValueVariableName() != null)
                 {
-                    if (GetValueVariableName().Equals(VariableController.NOVARIABLE))
+                    if (GetValueVariableName().Equals(VariableController.NO_VARIABLE))
                     {
 
                     }
@@ -821,7 +821,7 @@ namespace Controller.Data.Steps
             VariableController variable;
             if (GetValueVariableName() != null)
             {
-                if (GetValueVariableName().Equals(VariableController.NOVARIABLE))
+                if (GetValueVariableName().Equals(VariableController.NO_VARIABLE))
                 {
 
                 }
@@ -846,7 +846,7 @@ namespace Controller.Data.Steps
             }
             if (GetDurationVariableName() != null)
             {
-                if (GetDurationVariableName().Equals(VariableController.NOVARIABLE))
+                if (GetDurationVariableName().Equals(VariableController.NO_VARIABLE))
                 {
 
                 }
@@ -877,7 +877,7 @@ namespace Controller.Data.Steps
         /// <param name="parameter">The parameter.</param>
         public void SetUserInputDuration(object parameter)
         {
-            SetDurationVariableName(VariableController.NOVARIABLE);
+            SetDurationVariableName(VariableController.NO_VARIABLE);
             DurationVariable = null;
             if (null != this.PropertyChanged)
             {
@@ -892,7 +892,7 @@ namespace Controller.Data.Steps
         /// <param name="parameter">The parameter.</param>
         public void SetUserInputValue(object parameter)
         {
-            SetValueVariableName(VariableController.NOVARIABLE);
+            SetValueVariableName(VariableController.NO_VARIABLE);
             ValueVariable = null;
             if (null != this.PropertyChanged)
             {

--- a/Controller/Controller/Data/Steps/StepBasicController.cs
+++ b/Controller/Controller/Data/Steps/StepBasicController.cs
@@ -194,22 +194,15 @@ namespace Controller.Data.Steps
             }
             set
             {
-
-                //                System.Console.Write("SET Duration!\n");
                 if (GetDurationVariableName() == "" || GetDurationVariableName() == null)
                 {
                     SetDuration(value);
                 }
                 else
                 {
-                    //System.Console.Write("SET!\n");
                     SetDuration(DurationVariable.VariableValue);
-                    if (null != this.PropertyChanged)
-                    {
-                        PropertyChanged(this, new PropertyChangedEventArgs("Duration"));
-                    }
+                    UpdateProperty("Duration");
                 }
-                //System.Console.Write("set duration: {0}\n", value);
             }
         }
 
@@ -267,23 +260,14 @@ namespace Controller.Data.Steps
         {
             get
             {
-                //System.Console.Write("Duration, Get\n");
                 if (_durationVariable == null && GetDurationVariableName() != null)
                 {
-                    if (GetDurationVariableName().Equals(VariableController.NO_VARIABLE))
+                    if (!GetDurationVariableName().Equals(VariableController.NO_VARIABLE))
                     {
-
-                    }
-                    else
-                    {
-                        //System.Console.Write("Duration, Reattach\n");
                         ReattachVariable();
                     }
                 }
-                //if (_DurationVariable == null)
-                //{
-                //    throw new Exception("Variable is null");
-                //}
+
                 return _durationVariable;
             }
             set { _durationVariable = value; }
@@ -406,7 +390,7 @@ namespace Controller.Data.Steps
         /// The move right command.
         /// </value>
         public ICommand MoveRightCommand { get; private set; }
-    
+
         /// <summary>
         /// Gets or sets the command that is triggered when the remove item button is clicked
         /// </summary>
@@ -589,10 +573,7 @@ namespace Controller.Data.Steps
                 else
                 {
                     SetValue(ValueVariable.VariableValue);
-                    if (null != this.PropertyChanged)
-                    {
-                        PropertyChanged(this, new PropertyChangedEventArgs("Value"));
-                    }
+                    UpdateProperty("Value");
                 }
             }
         }
@@ -650,23 +631,14 @@ namespace Controller.Data.Steps
         {
             get
             {
-                //System.Console.Write("Value, Get\n");
                 if (_valueVariable == null && GetValueVariableName() != null)
                 {
-                    if (GetValueVariableName().Equals(VariableController.NO_VARIABLE))
+                    if (!GetValueVariableName().Equals(VariableController.NO_VARIABLE))
                     {
-
-                    }
-                    else
-                    {
-                        //System.Console.Write("Value, Reattach\n");
                         ReattachVariable();
                     }
                 }
-                //if (_ValueVariable == null)
-                //{
-                //    throw new Exception("Variable is null");
-                //}
+
                 return _valueVariable;
             }
             set { _valueVariable = value; }
@@ -722,9 +694,10 @@ namespace Controller.Data.Steps
                     {
                         throw new Exception("Variables == null!?!");
                     }
- 
+
                     _variables.VariablesListChanged += VariablesListChanged;
                     _variables.VariablesValueChanged += VariablesValueChanged;
+                    _variables.VariableTypeChanged += VariableTypeChanged;
                 }
 
                 return _variables;
@@ -783,6 +756,7 @@ namespace Controller.Data.Steps
                 if (controller.Message != GetMessageString())
                 {
                     SetMessageString(controller.Message);
+
                     if (null != this.PropertyChanged)
                     {
                         PropertyChanged(this, new PropertyChangedEventArgs("SetMessageMessage"));
@@ -813,24 +787,14 @@ namespace Controller.Data.Steps
         /// </exception>
         public void ReattachVariable()
         {
-            /*if (_rootController.Variables == null || _variables != null) 
-            {
-                return;
-            }*/
-
             VariableController variable;
+
             if (GetValueVariableName() != null)
             {
-                if (GetValueVariableName().Equals(VariableController.NO_VARIABLE))
+                if (!GetValueVariableName().Equals(VariableController.NO_VARIABLE))
                 {
-
-                }
-                else
-                {
-                    //checkVariablesDefined();
-                    //string str = GetValueVariableName();
-                    //System.Console.Write("str1: {0}\n", str);
                     variable = Variables.GetByName(GetValueVariableName());
+
                     if (variable != null)
                     {
                         SetValueVariableName(variable.VariableName);
@@ -840,22 +804,16 @@ namespace Controller.Data.Steps
                     else
                     {
                         throw new Exception("Variable is null");
-                        //SetValueVariableName(VariableController.NOVARIABLE);
                     }
                 }
             }
+
             if (GetDurationVariableName() != null)
             {
-                if (GetDurationVariableName().Equals(VariableController.NO_VARIABLE))
+                if (!GetDurationVariableName().Equals(VariableController.NO_VARIABLE))
                 {
-
-                }
-                else
-                {
-                    //checkVariablesDefined();
-                    //string str = GetDurationVariableName();
-                    //System.Console.Write("str2: {0}\n", str);
                     variable = Variables.GetByName(GetDurationVariableName());
+
                     if (variable != null)
                     {
                         SetDurationVariableName(variable.VariableName);
@@ -865,7 +823,6 @@ namespace Controller.Data.Steps
                     else
                     {
                         throw new Exception("Variable is null");
-                        //SetDurationVariableName(VariableController.NOVARIABLE);
                     }
                 }
             }
@@ -912,6 +869,7 @@ namespace Controller.Data.Steps
             SetDurationVariableName(variable.VariableName);
             DurationVariable = variable;
             Duration = DurationVariable.VariableValue;
+
             if (null != this.PropertyChanged)
             {
                 PropertyChanged(this, new PropertyChangedEventArgs("DurationColor"));
@@ -985,7 +943,7 @@ namespace Controller.Data.Steps
         /// </summary>
         /// <param name="sender">The sender.</param>
         /// <param name="changedVariable">The changed variable information.</param>
-        public void VariablesValueChanged(object sender, VariableController changedVariable)
+        private void VariablesValueChanged(object sender, VariableController changedVariable)
         {
 
             if (changedVariable.Equals(ValueVariable))
@@ -1003,6 +961,33 @@ namespace Controller.Data.Steps
                 SetDurationVariableName(DurationVariable.VariableName);
                 UpdateProperty("DurationVariableName");
                 UpdateProperty("DurationColor");
+            }
+        }
+
+        /// <summary>
+        /// Handles the evet that a variable has changed its type
+        /// </summary>
+        /// <param name="sender">The VariablesController</param>
+        /// <param name="newController">The VariableController created after the change (it is differet from the current one!)</param>
+        private void VariableTypeChanged(object sender, VariableController newController)
+        {
+            if (newController.VariableName == VariableController.NO_VARIABLE)
+                throw new Exception("Changing the type of a variable that has no name is not supported!");
+
+            if ((ValueVariable != null && newController.VariableName == ValueVariable.VariableName) ||
+                (DurationVariable != null && newController.VariableName == DurationVariable.VariableName))
+            {
+                ReattachVariable();
+
+                if (newController == ValueVariable)
+                {
+                    UpdateProperty("ValueColor");
+                }
+
+                if (newController == DurationVariable)
+                {
+                    UpdateProperty("DurationColor");
+                }
             }
         }
 
@@ -1161,9 +1146,9 @@ namespace Controller.Data.Steps
             List<MenuItem> result = new List<MenuItem>();
             List<MenuItem> currentSubList;
             MenuItem current;
-            List<KeyValuePair<int, string>> dictionaryAsList = new List<KeyValuePair<int,string>>(Variables.GroupNames);
+            List<KeyValuePair<int, string>> dictionaryAsList = new List<KeyValuePair<int, string>>(Variables.GroupNames);
             dictionaryAsList.Sort(
-                (item1, item2)=>
+                (item1, item2) =>
                 {
                     return item1.Value.CompareTo(item2.Value);
                 }

--- a/Controller/Controller/Variables/VariableController.cs
+++ b/Controller/Controller/Variables/VariableController.cs
@@ -22,7 +22,6 @@ namespace Controller.Variables
     /// </summary>
     public abstract class VariableController : BaseController
     {
-
         public readonly static string NO_VARIABLE = "";
 
         // ******************** variables ********************
@@ -32,6 +31,8 @@ namespace Controller.Variables
         /// A list of string representations of the locations in which this variable is being used.
         /// </summary>
         private List<string> usages = new List<string>();
+
+        private bool _variableLocked = false;
 
         public ICommand DeleteVariableCommand { get; private set; }
         public ICommand SwitchToStaticCommand { get; private set; }
@@ -70,7 +71,6 @@ namespace Controller.Variables
                 return false;
             }
         }
-
 
         /// <summary>
         /// Gets the list of usages of this variable as a single string
@@ -154,8 +154,6 @@ namespace Controller.Variables
             }
         }
 
-
-
         public int GroupIndex
         {
             get { return _model.groupIndex; }
@@ -218,20 +216,7 @@ namespace Controller.Variables
             }
         }
 
-        public void ClearUsages()
-        {
-            usages.Clear();
 
-            OnPropertyChanged("UsagesAsString");
-            OnPropertyChanged("VariableUsage");
-        }
-        public void AddUsage(string usage)
-        {
-            usages.Add(usage);
-            OnPropertyChanged("UsagesAsString");
-            OnPropertyChanged("VariableUsage");
-
-        }
 
         /// <summary>
         /// Value of the variable
@@ -289,7 +274,7 @@ namespace Controller.Variables
                 OnPropertyChanged("VariableLockedColor");
             }
         }
-        private bool _variableLocked = false;
+
 
         public SolidColorBrush VariableLockedColor
         {
@@ -418,6 +403,33 @@ namespace Controller.Variables
         }
 
         /// <summary>
+        /// Creates a new instance of this class based on an exiting instance;
+        /// </summary>
+        /// <param name="controller">The controller on whihc we want to base the new instance</param>
+        public VariableController(VariableController controller)
+            : this(controller._model, controller._parent)
+        {
+            IsGroupHeader = controller.IsGroupHeader;
+            VariableLocked = controller.VariableLocked;
+        }
+
+        public void ClearUsages()
+        {
+            usages.Clear();
+
+            OnPropertyChanged("UsagesAsString");
+            OnPropertyChanged("VariableUsage");
+        }
+
+        public void AddUsage(string usage)
+        {
+            usages.Add(usage);
+            OnPropertyChanged("UsagesAsString");
+            OnPropertyChanged("VariableUsage");
+
+        }
+
+        /// <summary>
         /// Determines whether this instance can move up or down.
         /// </summary>
         /// <param name="parameter">not used</param>
@@ -459,8 +471,7 @@ namespace Controller.Variables
         /// <param name="parameter"></param>
         public void SwitchToStatic(object parameter)
         {
-            _parent.SetVariableType(this, VariableType.VariableTypeStatic);
-            UpdateVariablesListFromParent();
+            _parent.ChangeVariableType(this, VariableType.VariableTypeStatic);
         }
 
         /// <summary>
@@ -469,8 +480,7 @@ namespace Controller.Variables
         /// <param name="parameter"></param>
         public void SwitchToIterator(object parameter)
         {
-            _parent.SetVariableType(this, VariableType.VariableTypeIterator);
-            UpdateVariablesListFromParent();
+            _parent.ChangeVariableType(this, VariableType.VariableTypeIterator);
         }
 
         /// <summary>
@@ -479,8 +489,7 @@ namespace Controller.Variables
         /// <param name="parameter"></param>
         public void SwitchToDynamic(object parameter)
         {
-            _parent.SetVariableType(this, VariableType.VariableTypeDynamic);
-            UpdateVariablesListFromParent();
+            _parent.ChangeVariableType(this, VariableType.VariableTypeDynamic);
         }
 
         /// <summary>

--- a/Controller/Controller/Variables/VariableController.cs
+++ b/Controller/Controller/Variables/VariableController.cs
@@ -33,13 +33,13 @@ namespace Controller.Variables
         /// </summary>
         private List<string> usages = new List<string>();
 
-        public ICommand DeleteVariable { get; private set; }
-        public ICommand SwitchToStatic { get; private set; }
-        public ICommand SwitchToIterator { get; private set; }
-        public ICommand SwitchToDynamic { get; private set; }
-        public ICommand MoveUp { get; private set; }
-        public ICommand MoveDown { get; private set; }
-        public ICommand RemoveGroup { get; private set; }
+        public ICommand DeleteVariableCommand { get; private set; }
+        public ICommand SwitchToStaticCommand { get; private set; }
+        public ICommand SwitchToIteratorCommand { get; private set; }
+        public ICommand SwitchToDynamicCommand { get; private set; }
+        public ICommand MoveUpCommand { get; private set; }
+        public ICommand MoveDownCommand { get; private set; }
+        public ICommand RemoveGroupCommand { get; private set; }
         public ICommand MouseDownCommand { get; private set; }
         // ******************** properties ********************
 
@@ -102,12 +102,10 @@ namespace Controller.Variables
 
         }
 
-        private bool _isGroupHeader = false;
-
         public bool IsGroupHeader
         {
-            get { return _isGroupHeader; }
-            set { _isGroupHeader = value; }
+            get;
+            set;
         }
 
         public int getModelIndex
@@ -186,7 +184,7 @@ namespace Controller.Variables
         /// <summary>
         /// Name of the variable
         /// </summary>
-        public String VariableName
+        public string VariableName
         {
             get { return _model.VariableName; }
             set
@@ -198,6 +196,7 @@ namespace Controller.Variables
                 else
                 {
                     _parent.CheckAllVariablesUsage(null);
+
                     if (Used)
                     {
                         MessageBoxResult result = MessageBox.Show("The variable is used in the following places:\n" + UsagesAsString + "\nIf you continue, it will be renamed everywhere?", "Rename Confirmation", MessageBoxButton.OKCancel, MessageBoxImage.Warning);
@@ -207,7 +206,7 @@ namespace Controller.Variables
                             RenameVariableInPythonScripts(value);
 
                             _model.VariableName = value;
-                            updateVariablesListFromParent();
+                            UpdateVariablesListFromParent();
                             _parent.DoVariablesValueChanged(this);
                         }
 
@@ -215,7 +214,7 @@ namespace Controller.Variables
                     else
                     {
                         _model.VariableName = value;
-                        updateVariablesListFromParent();
+                        UpdateVariablesListFromParent();
                         _parent.DoVariablesValueChanged(this);
                     }
                 }
@@ -279,7 +278,7 @@ namespace Controller.Variables
             {
                 _model.VariableStartValue = value;
                 _parent.ResetIteratorValues();
-                _parent.countTotalNumberOfIterations();
+                _parent.CountTotalNumberOfIterations();
             }
         }
 
@@ -318,7 +317,7 @@ namespace Controller.Variables
 
                 _model.VariableEndValue = value;
                 _parent.DoVariablesValueChanged(this);
-                _parent.countTotalNumberOfIterations();
+                _parent.CountTotalNumberOfIterations();
             }
         }
 
@@ -333,7 +332,7 @@ namespace Controller.Variables
 
                 _model.VariableStepValue = value;
                 _parent.DoVariablesValueChanged(this);
-                _parent.countTotalNumberOfIterations();
+                _parent.CountTotalNumberOfIterations();
             }
         }
 
@@ -368,16 +367,18 @@ namespace Controller.Variables
                 // we need to newly calculate the number of iterations when we have a new iterator, or we remove one
                 if (value == VariableType.VariableTypeIterator || oldType == VariableType.VariableTypeIterator)
                 {
-                    _parent.countTotalNumberOfIterations();
+                    _parent.CountTotalNumberOfIterations();
                 }
+
                 _parent.DoVariablesValueChanged(this);
-                if (this.VariableName != NOVARIABLE)
+
+                if (VariableName != NOVARIABLE)
                 {
                     foreach (VariableController variable in _parent.VariablesDynamic)
                     {
-                        if (variable.VariableCode.Contains(this.VariableName))
+                        if (PythonScriptVariablesAnalyzer.IsVariableUsedInScript(VariableName, variable.VariableCode))
                         {
-                            System.Console.Write("{0} depends on {1}\n", variable.VariableName, this.VariableName);
+                            Console.Write("{0} depends on {1}\n", variable.VariableName, this.VariableName);
                             _parent.DoVariablesValueChanged(variable);
                         }
                     }
@@ -422,7 +423,7 @@ namespace Controller.Variables
 
         public List<MenuItem> staticGroups
         {
-            get { return _parent.constructStaticGroups(this); }
+            get { return _parent.ConstructStaticGroups(this); }
         }
 
 
@@ -436,13 +437,13 @@ namespace Controller.Variables
         {
             _model = variableModel;
             _parent = parent;
-            SwitchToStatic = new RelayCommand(switchToStatic);
-            SwitchToIterator = new RelayCommand(switchToIterator);
-            SwitchToDynamic = new RelayCommand(switchToDynamic);
-            DeleteVariable = new RelayCommand(deleteVariable);
-            MoveUp = new RelayCommand(moveUp, CanMoveUpOrDown);
-            MoveDown = new RelayCommand(moveDown, CanMoveUpOrDown);
-            RemoveGroup = new RelayCommand(DoRemoveGroup);
+            SwitchToStaticCommand = new RelayCommand(SwitchToStatic);
+            SwitchToIteratorCommand = new RelayCommand(SwitchToIterator);
+            SwitchToDynamicCommand = new RelayCommand(SwitchToDynamic);
+            DeleteVariableCommand = new RelayCommand(DeleteVariable);
+            MoveUpCommand = new RelayCommand(MoveUp, CanMoveUpOrDown);
+            MoveDownCommand = new RelayCommand(MoveDown, CanMoveUpOrDown);
+            RemoveGroupCommand = new RelayCommand(DoRemoveGroup);
             MouseDownCommand = new RelayCommand(OnMouseDown);
         }
 
@@ -477,7 +478,7 @@ namespace Controller.Variables
         /// Deletes the current variable.
         /// </summary>
         /// <param name="parameter">not used</param>
-        public void deleteVariable(object parameter)
+        public void DeleteVariable(object parameter)
         {
             _parent.RemoveVariable(this);
         }
@@ -486,57 +487,57 @@ namespace Controller.Variables
         /// Switches the type of this variable to static
         /// </summary>
         /// <param name="parameter"></param>
-        public void switchToStatic(object parameter)
+        public void SwitchToStatic(object parameter)
         {
             this.TypeOfVariable = VariableType.VariableTypeStatic;
-            updateVariablesListFromParent();
+            UpdateVariablesListFromParent();
         }
 
         /// <summary>
         /// Switches the type of this variable to iterator
         /// </summary>
         /// <param name="parameter"></param>
-        public void switchToIterator(object parameter)
+        public void SwitchToIterator(object parameter)
         {
             this.TypeOfVariable = VariableType.VariableTypeIterator;
-            updateVariablesListFromParent();
+            UpdateVariablesListFromParent();
         }
 
         /// <summary>
         /// Switches the variable to dynamic
         /// </summary>
         /// <param name="parameter"></param>
-        public void switchToDynamic(object parameter)
+        public void SwitchToDynamic(object parameter)
         {
             this.TypeOfVariable = VariableType.VariableTypeDynamic;
-            updateVariablesListFromParent();
+            UpdateVariablesListFromParent();
         }
 
         /// <summary>
         /// Move the Variable 1 up
         /// </summary>
         /// <param name="parameter"></param>
-        public void moveUp(object parameter)
+        public void MoveUp(object parameter)
         {
-            _parent.moveUp(this);
+            _parent.MoveUp(this);
         }
 
         /// <summary>
         /// Move the Variable 1 down
         /// </summary>
         /// <param name="parameter"></param>
-        public void moveDown(object parameter)
+        public void MoveDown(object parameter)
         {
-            _parent.moveDown(this);
+            _parent.MoveDown(this);
         }
 
 
         /// <summary>
-        /// Calls an updateVariablesListFromParent of the variable List (e.g. if the type of this variable is changed so it will be assigned to another variable type list.
+        /// Calls an updateVariablesListFromParent of the variable List (e.g. if the type of this variable is changed so it will be assigned to another variable type list.)
         /// </summary>
-        public void updateVariablesListFromParent()
+        public void UpdateVariablesListFromParent()
         {
-            System.Console.WriteLine("Update variable list");
+            Console.WriteLine("Update variable list");
             _parent.UpdateVariablesList();
         }
 

--- a/Controller/Controller/Variables/VariableController.cs
+++ b/Controller/Controller/Variables/VariableController.cs
@@ -22,11 +22,11 @@ namespace Controller.Variables
     /// </summary>
     public abstract class VariableController : BaseController
     {
+
+        public readonly static string NO_VARIABLE = "";
+
         // ******************** variables ********************
         private VariablesController _parent;
-
-
-
         public VariableModel _model;
         /// <summary>
         /// A list of string representations of the locations in which this variable is being used.
@@ -154,10 +154,7 @@ namespace Controller.Variables
             }
         }
 
-        public static string NOVARIABLE
-        {
-            get { return ""; }
-        }
+
 
         public int GroupIndex
         {
@@ -358,33 +355,6 @@ namespace Controller.Variables
         public VariableType TypeOfVariable
         {
             get { return _model.TypeOfVariable; }
-            set
-            {
-                object errorNotificationsLock = ErrorCollector.Instance.StartBulkUpdate();
-                object bufferUpdateLock = _parent.GetRootController().BulkUpdateStart();
-                VariableType oldType = _model.TypeOfVariable;
-                _model.TypeOfVariable = value;
-                // we need to newly calculate the number of iterations when we have a new iterator, or we remove one
-                if (value == VariableType.VariableTypeIterator || oldType == VariableType.VariableTypeIterator)
-                {
-                    _parent.CountTotalNumberOfIterations();
-                }
-
-                _parent.DoVariablesValueChanged(this);
-
-                if (VariableName != NOVARIABLE)
-                {
-                    foreach (VariableController variable in _parent.VariablesDynamic)
-                    {
-                        if (PythonScriptVariablesAnalyzer.IsVariableUsedInScript(VariableName, variable.VariableCode))
-                        {
-                            Console.Write("{0} depends on {1}\n", variable.VariableName, this.VariableName);
-                            _parent.DoVariablesValueChanged(variable);
-                        }
-                    }
-                }
-                _parent.VariableUpdateDone(bufferUpdateLock, errorNotificationsLock);
-            }
         }
 
         /// <summary>
@@ -489,7 +459,7 @@ namespace Controller.Variables
         /// <param name="parameter"></param>
         public void SwitchToStatic(object parameter)
         {
-            this.TypeOfVariable = VariableType.VariableTypeStatic;
+            _parent.SetVariableType(this, VariableType.VariableTypeStatic);
             UpdateVariablesListFromParent();
         }
 
@@ -499,7 +469,7 @@ namespace Controller.Variables
         /// <param name="parameter"></param>
         public void SwitchToIterator(object parameter)
         {
-            this.TypeOfVariable = VariableType.VariableTypeIterator;
+            _parent.SetVariableType(this, VariableType.VariableTypeIterator);
             UpdateVariablesListFromParent();
         }
 
@@ -509,7 +479,7 @@ namespace Controller.Variables
         /// <param name="parameter"></param>
         public void SwitchToDynamic(object parameter)
         {
-            this.TypeOfVariable = VariableType.VariableTypeDynamic;
+            _parent.SetVariableType(this, VariableType.VariableTypeDynamic);
             UpdateVariablesListFromParent();
         }
 

--- a/Controller/Controller/Variables/VariableDynamicController.cs
+++ b/Controller/Controller/Variables/VariableDynamicController.cs
@@ -8,5 +8,9 @@ namespace Controller.Variables
         public VariableDynamicController(VariableModel variableModel, VariablesController parent) : base(variableModel, parent)
         {
         }
+
+        public VariableDynamicController(VariableController basis)
+            : base(basis)
+        { }
     }
 }

--- a/Controller/Controller/Variables/VariableIteratorController.cs
+++ b/Controller/Controller/Variables/VariableIteratorController.cs
@@ -7,5 +7,9 @@ namespace Controller.Variables
         public VariableIteratorController(VariableModel variableModel, VariablesController parent) : base(variableModel, parent)
         {
         }
+
+        public VariableIteratorController(VariableController basis)
+            : base(basis)
+        { }
     }
 }

--- a/Controller/Controller/Variables/VariableStaticController.cs
+++ b/Controller/Controller/Variables/VariableStaticController.cs
@@ -7,5 +7,9 @@ namespace Controller.Variables
         public VariableStaticController(VariableModel variableModel, VariablesController parent) : base(variableModel, parent)
         {
         }
+
+        public VariableStaticController(VariableController basis)
+            : base(basis)
+        { }
     }
 }

--- a/Controller/Controller/Variables/VariablesController.cs
+++ b/Controller/Controller/Variables/VariablesController.cs
@@ -264,8 +264,6 @@ namespace Controller.Variables
             VariableController variable = new VariableDynamicController(variableModel, this);
             Variables.Add(variable);
             SetVariableType(variable, VariableType.VariableTypeDynamic);
-
-
         }
 
         /// <summary>
@@ -1012,6 +1010,13 @@ namespace Controller.Variables
             _parentController = parentController;
         }
 
+        /// <summary>
+        /// Changes the type of the specified variable to the specified VariableType.
+        /// This is done by creating a new VariableController for the variable and replacing the old controller with it.
+        /// </summary>
+        /// <param name="variableController">The controller of the variable to be replaced</param>
+        /// <param name="newType">the new type of the variable</param>
+        /// <returns>A newly created variables controller that represents the variable with its new type.</returns>
         public VariableController ChangeVariableType(VariableController variableController, VariableType newType)
         {
             object token = ErrorCollector.Instance.StartBulkUpdate();
@@ -1039,6 +1044,12 @@ namespace Controller.Variables
             return result;
         }
 
+        /// <summary>
+        /// Associates a type to a (new or existing) variable. This triggers side effects if the type of the variable is iterator (since total number of iterations
+        /// might change), or if the variable is being used within other dynamic variables.
+        /// </summary>
+        /// <param name="variableController"></param>
+        /// <param name="newType"></param>
         private void SetVariableType(VariableController variableController, VariableType newType)
         {
             object errorNotificationsLock = ErrorCollector.Instance.StartBulkUpdate();

--- a/View/View/Data/Steps/StepBasicView.xaml
+++ b/View/View/Data/Steps/StepBasicView.xaml
@@ -29,9 +29,9 @@
             TextAlignment="Right">
             <TextBlock.ContextMenu>
                 <ContextMenu>
-                    <MenuItem Command="{Binding Insert}" Header="Insert" />
-                    <MenuItem Command="{Binding MoveLeft}" Header="Move left" />
-                    <MenuItem Command="{Binding MoveRight}" Header="Move right" />
+                    <MenuItem Command="{Binding InsertCommand}" Header="Insert" />
+                    <MenuItem Command="{Binding MoveLeftCommand}" Header="Move left" />
+                    <MenuItem Command="{Binding MoveRightCommand}" Header="Move right" />
                 </ContextMenu>
             </TextBlock.ContextMenu>
         </TextBlock>

--- a/View/View/Variables/VariableTypes/VariableBasicView.xaml
+++ b/View/View/Variables/VariableTypes/VariableBasicView.xaml
@@ -17,27 +17,27 @@
                 <ContextMenu>
                     <MenuItem
                         Name="Static"
-                        Command="{Binding SwitchToStatic}"
+                        Command="{Binding SwitchToStaticCommand}"
                         Header="Static" />
                     <MenuItem
                         Name="Iterator"
-                        Command="{Binding SwitchToIterator}"
+                        Command="{Binding SwitchToIteratorCommand}"
                         Header="Iterator" />
                     <MenuItem
                         Name="Dynamic"
-                        Command="{Binding SwitchToDynamic}"
+                        Command="{Binding SwitchToDynamicCommand}"
                         Header="Dynamic" />
                     <MenuItem
                         Name="DeleteVariable"
-                        Command="{Binding DeleteVariable}"
+                        Command="{Binding DeleteVariableCommand}"
                         Header="Delete This Variable" />
                     <MenuItem
                         Name="MoveUp"
-                        Command="{Binding MoveUp}"
+                        Command="{Binding MoveUpCommand}"
                         Header="Move Up" />
                     <MenuItem
                         Name="MoveDown"
-                        Command="{Binding MoveDown}"
+                        Command="{Binding MoveDownCommand}"
                         Header="Move Down" />
                     <MenuItem
                         Name="MoveToGroup"

--- a/View/View/Variables/VariableTypes/VariableGroupHeaderView.xaml
+++ b/View/View/Variables/VariableTypes/VariableGroupHeaderView.xaml
@@ -1,25 +1,35 @@
-﻿<UserControl x:Class="View.Variables.VariableTypes.VariableGroupHeaderView"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:VariableTypes="clr-namespace:View.Variables.VariableTypes"
-             xmlns:SubmitTextBox="clr-namespace:CustomElements.SubmitTextBox;assembly=CustomElements" mc:Ignorable="d" 
-             d:DesignHeight="28" d:DesignWidth="200">
+﻿<UserControl
+    x:Class="View.Variables.VariableTypes.VariableGroupHeaderView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:SubmitTextBox="clr-namespace:CustomElements.SubmitTextBox;assembly=CustomElements"
+    xmlns:VariableTypes="clr-namespace:View.Variables.VariableTypes"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    d:DesignHeight="28"
+    d:DesignWidth="200"
+    mc:Ignorable="d">
 
 
-	<Grid>
-		<Grid.ColumnDefinitions>
-			<!--<ColumnDefinition Width="25"></ColumnDefinition>-->
-			<ColumnDefinition Width="*"></ColumnDefinition>
-		</Grid.ColumnDefinitions>
-		<!--<TextBox IsReadOnly="True" Text="{Binding GroupIndex}" Grid.Column="0" Background="LightPink"></TextBox>-->
-		<SubmitTextBox:SubmitTextBox Grid.Column="1" Text="{Binding GroupName, Mode=TwoWay}" Name="VariableValue" Background="LightPink">
-			<SubmitTextBox:SubmitTextBox.ContextMenu>
-				<ContextMenu>
-					<MenuItem Name="RemoveGroup" Header="Remove Group" Command="{Binding RemoveGroup}"></MenuItem>
-				</ContextMenu>
-			</SubmitTextBox:SubmitTextBox.ContextMenu>
-		</SubmitTextBox:SubmitTextBox>
-	</Grid>
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <!--<ColumnDefinition Width="25"></ColumnDefinition>-->
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <!--<TextBox IsReadOnly="True" Text="{Binding GroupIndex}" Grid.Column="0" Background="LightPink"></TextBox>-->
+        <SubmitTextBox:SubmitTextBox
+            Name="VariableValue"
+            Grid.Column="1"
+            Background="LightPink"
+            Text="{Binding GroupName, Mode=TwoWay}">
+            <SubmitTextBox:SubmitTextBox.ContextMenu>
+                <ContextMenu>
+                    <MenuItem
+                        Name="RemoveGroupCommand"
+                        Command="{Binding RemoveGroup}"
+                        Header="Remove Group" />
+                </ContextMenu>
+            </SubmitTextBox:SubmitTextBox.ContextMenu>
+        </SubmitTextBox:SubmitTextBox>
+    </Grid>
 </UserControl>

--- a/View/View/Variables/VariablesView.xaml
+++ b/View/View/Variables/VariablesView.xaml
@@ -53,7 +53,7 @@
                 Name="addStatic"
                 Grid.Row="3"
                 Grid.Column="0"
-                Command="{Binding AddStatic}">
+                Command="{Binding AddStaticCommand}">
                 Add Static
             </Button>
             <Grid Grid.Row="1" Grid.Column="0">
@@ -106,7 +106,7 @@
                 Name="addIterator"
                 Grid.Row="3"
                 Grid.Column="1"
-                Command="{Binding AddIterator}">
+                Command="{Binding AddIteratorCommand}">
                 Add Iterator
             </Button>
             <Grid Grid.Row="1" Grid.Column="1">
@@ -175,7 +175,7 @@
                 Name="addDynamic"
                 Grid.Row="3"
                 Grid.Column="2"
-                Command="{Binding AddDynamic}">
+                Command="{Binding AddDynamicCommand}">
                 Add Dynamic
             </Button>
             <Grid Grid.Row="1" Grid.Column="2">
@@ -226,8 +226,8 @@
                 <ColumnDefinition Width="100" />
             </Grid.ColumnDefinitions>
             <Button Command="{Binding EvaluateCommand}">Evaluate</Button>
-            <Button Grid.Column="1" Command="{Binding Iterate}">Iterate</Button>
-            <Button Grid.Column="2" Command="{Binding Check}">Check Usage</Button>
+            <Button Grid.Column="1" Command="{Binding IterateCommand}">Iterate</Button>
+            <Button Grid.Column="2" Command="{Binding CheckCommand}">Check Usage</Button>
         </Grid>
     </Grid>
 </UserControl>


### PR DESCRIPTION
The cause of the problem was the way `ViewModel` are mapped to `Views`:
Before the last release, this mapping (for Variables) was done using a XAML-based selection mechanism (the selection logic was embedded into the `View` itself). 
In the last release, all a different mapping mechanism was introduced that maintains the MVVM architectural pattern.
However, this introduced a bug when changing the type of the variable: unless the program restarts the view of the variable was not updating to reflect the changed view model.
This pull request fixes this issue by correctly handling this procedure via the `ChangeVariableType` method of the `VariablesController` class.

- introduces code readability enhancements
- fixes #38 