### PR TITLE
Fix Issue: When Changing Type of Variable, Iterations Count Not Updating Properly

### DIFF
--- a/Controller/Controller/Data/Steps/StepBasicController.cs
+++ b/Controller/Controller/Data/Steps/StepBasicController.cs
@@ -909,7 +909,7 @@ namespace Controller.Data.Steps
         }
 
         /// <summary>
-        /// Executed when the variables' list changes
+        /// Executed when any of the variable lists change
         /// </summary>
         /// <param name="sender">The sender.</param>
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>

--- a/Controller/Controller/MainWindow/MainWindowController.cs
+++ b/Controller/Controller/MainWindow/MainWindowController.cs
@@ -677,7 +677,7 @@ namespace Controller.MainWindow
 
         public int NumberOfIterations
         {
-            get { return _variables.numberOfIterations; }
+            get { return _variables.NumberOfIterations; }
         }
 
         /// <summary>

--- a/Controller/Controller/Variables/VariableController.cs
+++ b/Controller/Controller/Variables/VariableController.cs
@@ -202,7 +202,7 @@ namespace Controller.Variables
 
                             _model.VariableName = value;
                             UpdateVariablesListFromParent();
-                            _parent.DoVariablesValueChanged(this);
+                            _parent.SignalVariableValueChanged(this);
                         }
 
                     }
@@ -210,7 +210,7 @@ namespace Controller.Variables
                     {
                         _model.VariableName = value;
                         UpdateVariablesListFromParent();
-                        _parent.DoVariablesValueChanged(this);
+                        _parent.SignalVariableValueChanged(this);
                     }
                 }
             }
@@ -237,7 +237,7 @@ namespace Controller.Variables
               
                 System.Console.Write("variable {0}: {1}\n", _model.VariableName, value);
                 _model.VariableValue = value;
-                _parent.DoVariablesValueChanged(this);
+                _parent.SignalVariableValueChanged(this);
                 OnPropertyChanged("VariableValue");
 
                 //TODO this could be an error
@@ -298,7 +298,7 @@ namespace Controller.Variables
             {
 
                 _model.VariableEndValue = value;
-                _parent.DoVariablesValueChanged(this);
+                _parent.SignalVariableValueChanged(this);
                 _parent.CountTotalNumberOfIterations();
             }
         }
@@ -313,7 +313,7 @@ namespace Controller.Variables
             {
 
                 _model.VariableStepValue = value;
-                _parent.DoVariablesValueChanged(this);
+                _parent.SignalVariableValueChanged(this);
                 _parent.CountTotalNumberOfIterations();
             }
         }

--- a/GeneratorUT/GeneratorUT.csproj
+++ b/GeneratorUT/GeneratorUT.csproj
@@ -95,6 +95,7 @@
     <Compile Include="BasicStepUT.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ModelExportUT.cs" />
+    <Compile Include="VariablesControllerUT.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/GeneratorUT/VariablesControllerUT.cs
+++ b/GeneratorUT/VariablesControllerUT.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using Controller.MainWindow;
+using Controller.Variables;
+using MainProject.Builders;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+
+namespace GeneratorUT
+{
+    [TestClass]
+    public class VariablesControllerUT: ParentUT
+    {
+        [DataRow("Dy4thFloor")]
+        [TestMethod]
+        public void TestChangeVariableTypeToIterator(string profileName)
+        {
+            const int START = 0;
+            const int STOP = 10;
+            const int STEP = 1;
+            int steps = (STOP - START + 1) / STEP;
+
+            SelectProfile(profileName);
+            MasterBuilder builder = new MasterBuilder();
+            builder.Build();
+            MainWindowController mainWindowController = builder.GetMainController();
+            VariablesController controller = mainWindowController.GetRootController().Variables;
+            Assert.AreEqual(0, controller.VariablesStatic.Count);
+            Assert.AreEqual(0, controller.VariablesDynamic.Count);
+            Assert.AreEqual(0, controller.VariablesIterator.Count);
+            Assert.AreEqual(1, controller.NumberOfIterations);
+            controller.AddStaticCommand.Execute(null);
+            // group header + variable
+            Assert.AreEqual(2, controller.VariablesStatic.Count);
+            Assert.AreEqual(0, controller.VariablesDynamic.Count);
+            Assert.AreEqual(0, controller.VariablesIterator.Count);
+            Assert.AreEqual(1, controller.NumberOfIterations);
+            VariableController variable = controller.VariablesStatic
+                .Where(value => value is VariableStaticController)
+                .First();
+            Assert.IsNotNull(variable);
+            Assert.IsInstanceOfType(variable, typeof(VariableStaticController));
+            // prepare the iterator-specific values before changing type to iterator (RIP OOP :))
+            variable.VariableStartValue = 0;
+            variable.VariableStepValue = 1;
+            variable.VariableEndValue = 10;
+            Assert.AreEqual(1, controller.NumberOfIterations);
+            variable = controller.ChangeVariableType(variable, Communication.VariableType.VariableTypeIterator);
+            Assert.IsNotNull(variable);
+            Assert.IsInstanceOfType(variable, typeof(VariableIteratorController));
+            // group header
+            Assert.AreEqual(1, controller.VariablesStatic.Count);
+            Assert.AreEqual(0, controller.VariablesDynamic.Count);
+            // variable
+            Assert.AreEqual(1, controller.VariablesIterator.Count);
+            Assert.AreEqual(steps, controller.NumberOfIterations);
+
+            variable = controller.ChangeVariableType(variable, Communication.VariableType.VariableTypeStatic);            Assert.IsNotNull(variable);
+            Assert.IsInstanceOfType(variable, typeof(VariableStaticController));
+            // group header + variable
+            Assert.AreEqual(2, controller.VariablesStatic.Count);
+            Assert.AreEqual(0, controller.VariablesDynamic.Count);
+            Assert.AreEqual(0, controller.VariablesIterator.Count);
+            Assert.AreEqual(1, controller.NumberOfIterations);
+
+
+        }
+    }
+}


### PR DESCRIPTION
- The issue was that the internal lists of variables where only updated after the switching was complete. However, the switching code itself assumed that the variable lists are updated, and it depended on them. Now, variable lists are updated while switching not afterwards.
- Implemented a Unit Test.
- Reorganized `VariablesController`.
- Ensured no methods are unnecessarily `public` in `VariablesController`.
- Fixes #42 