### PR TITLE
Fix issue of double GC increase in one cycle when AlwaysIncrease checked and model change occured

### DIFF
--- a/Buffer/Buffer/Basic/DoubleBuffer.cs
+++ b/Buffer/Buffer/Basic/DoubleBuffer.cs
@@ -419,12 +419,7 @@ namespace Buffer.Basic
         /// </summary>
         private void UpdateGeneratorState()
         {
-            EventHandler update = OnGeneratorStateChange;
-
-            if (null != update)
-            {
-                update(this, null);
-            }
+            OnGeneratorStateChange?.Invoke(this, null);
         }
 
 

--- a/Buffer/Buffer/Basic/OutputHandler.cs
+++ b/Buffer/Buffer/Basic/OutputHandler.cs
@@ -19,6 +19,7 @@ using System.Text;
 using Model.MeasurementRoutine.GlobalVariables;
 using Model.MeasurementRoutine;
 using PythonUtils.FileExecution;
+using Buffer.DatabaseAccess;
 
 namespace Buffer.Basic
 {
@@ -215,6 +216,11 @@ namespace Buffer.Basic
         /// The hardware manager that is used to communicate with the hardware.
         /// </summary>
         private readonly IHardwareManager _hardwareManager;
+
+        /// <summary>
+        /// Provides access to the underlying database.
+        /// </summary>
+        private readonly DatabaseManager _databaseManager;
         /// <summary>
         /// The root to the data model hierarchy
         /// </summary>
@@ -575,9 +581,10 @@ namespace Buffer.Basic
             BasicPythonFileExecutorBuilder builder = new BasicPythonFileExecutorBuilder();
             this.pyExecutor = (BasicPythonFileExecutor)builder.Build();
             _hardwareManager = hardwareManager;
-
+            _databaseManager = new DatabaseManager();
+            
             // increase global counter by one so nothing will be overwritten
-            GlobalCounter = LoadGlobalCounter() + 1;
+            GlobalCounter = _databaseManager.LoadGlobalCounter() + 1;
             ModelCounters = new ModelSpecificCounters();
             // the output thread is created once and runs 'till the program stops
             outputThread = new Thread(OutputLoop)
@@ -684,12 +691,10 @@ namespace Buffer.Basic
                                                  cycleState == CycleStates.ScanningOnce;
 
 
-
-
                     // everything has to wait until the variables and so on are stored in the database
                     /***/
-
-                    CreateDatabaseEntry(workLoopCopy);
+                    EntryPOCO databaseEntry = GenerateDBEntryPOCO(workLoopCopy);
+                    _databaseManager.CreateDatabaseEntry(databaseEntry);
 
 
                     // start python scripts as a background thread
@@ -988,8 +993,7 @@ namespace Buffer.Basic
 
         private void DoAfterIteratingVariables()
         {
-            if (AfterIteratingVariables != null)
-                AfterIteratingVariables(this, null);
+            AfterIteratingVariables?.Invoke(this, null);
         }
 
         /// <summary>
@@ -1173,211 +1177,23 @@ namespace Buffer.Basic
         }
 
 
-
-        //  *********************************** database **********************************************************        
-        /// <summary>
-        /// Opens a connection with the MySql database.
-        /// </summary>
-        /// <param name="setting">The setting that holds the connection parameters.</param>
-        /// <returns>An open connection to the database.</returns>
-        public MySqlConnection ConnectDatabase(DatabaseConnectionSetting setting)//TODO probably should use the "using" model of connection; safer!
+        //  *********************************** Database Access **********************************************************
+        private EntryPOCO GenerateDBEntryPOCO(RootModel rootModel)
         {
-            string server = setting.Server;
-            string database = setting.Database;
-            string uid = setting.UserName;
-            string password = setting.Password;
-            string port = setting.Port.ToString();
-
-            string connectionString = "SERVER=" + server + ";PORT=" + port + ";DATABASE=" +
-                                     database + ";UID=" + uid + ";PASSWORD=" + password + ";SslMode=none;";
-            MySqlConnection connection = null;
-
-            try
-            {
-                connection = new MySqlConnection(connectionString);
-                connection.Open();
-            }
-            catch (Exception e)
-            {
-                var errorCollector = ErrorCollector.Instance;
-                errorCollector.AddError("Could not connect to SQL database!" + e, ErrorCategory.Basic, true,
-                    ErrorTypes.FileNameEmpty);
-            }
-
-            return connection;
-        }
-
-        /// <summary>
-        /// Saves the variables and the scan progress/settings to the database
-        /// </summary>
-        /// <param name="model">the model</param>
-        private void CreateDatabaseEntry(RootModel model)
-        {
-            var variablesList = new List<String>();
-            model.VariablesList = variablesList;
-            var iteratorList = new List<String>();
-
-            // create list 
-            foreach (VariableModel variable in model.Data.variablesModel.VariablesList)
-            {
-                if (variable.VariableName.Trim() == "")
-                {
-                    continue;
-                }
-
-                variablesList.Add(variable.VariableName + "\t" + variable.VariableValue.ToString(CultureInfo.InvariantCulture));
-
-                if (variable.IsIterator())
-                {
-                    iteratorList.Add(variable.VariableName + "\t" + variable.VariableValue.ToString(CultureInfo.InvariantCulture) + "\t" + variable.VariableStartValue.ToString(CultureInfo.InvariantCulture) + "\t" + variable.VariableEndValue.ToString(CultureInfo.InvariantCulture) + "\t" + variable.VariableStepValue.ToString(CultureInfo.InvariantCulture));
-
-                }
-            }
-
-
-            // add additional variables
-            variablesList.Add("cntGlobal" + "\t" + model.GlobalCounter);
-            variablesList.Add("StartCounterOfScans" + "\t" + StartCounterOfScansOfCurrentModel);
-            variablesList.Add("StartCounterOfRoutine" + "\t" + StartGlobalCounterOfMeasurementRoutine);
-
-            // variablesList.Add("StartCounterOfScans" + "\t" + StartCounterOfScans);
-            variablesList.Add("IterationOfScan" + "\t" + IterationOfScan);
-            variablesList.Add("CompletedScans" + "\t" + CompletedScans);
-            variablesList.Add("NumberOfIterations" + "\t" + NumberOfIterations);
-            variablesList.Add("CycleDuration" + "\t" + _cycleDuration.ToString(CultureInfo.InvariantCulture));
-
-            //ADDED Ghareeb 05.10.2016 do not try any access to DB if not allowed
-            if (Global.CanAccessDatabase())
-            {
-                DatabaseConnectionSetting setting = (DatabaseConnectionSetting)ProfilesManager.GetInstance().ActiveProfile.GetSettingByName(SettingNames.DATABASE_CONNECTION);
-                //save to sql database
-                string sqlVariables = String.Join("\n", variablesList);
-                string sqlIterators = String.Join("\n", iteratorList);
-                MySqlConnection connection = null;
-
-
-                try
-                {
-                    connection = ConnectDatabase(setting);//TODO the exception is already handled!
-                }
-                catch (Exception e)
-                {
-                    var errorCollector = ErrorCollector.Instance;
-                    errorCollector.AddError("Could not connect to SQL database!" + e, ErrorCategory.Basic, true,
-                        ErrorTypes.FileNameEmpty);
-                }
-
-                string table = setting.Table;
-                DateTime estimatedStartTime = model.EstimatedStartTime;
-                string query = "";
-
-                if (!ProfilesManager.GetInstance().ActiveProfile.GetSettingValueByName<bool>(SettingNames.USE_LEGACY_DATABASE))//We need to use new schema
-                {
-                    OperatingMode currentMode;
-
-                    if (IsMeasurementRoutineMode)
-                    {
-                        currentMode = OperatingMode.MEASUREMENT_ROUTINE;
-                    }
-                    else if (model.IsItererating)
-                        currentMode = OperatingMode.ITERATION;
-                    else
-                        currentMode = OperatingMode.STATIC;
-
-                    int modelNumber = ModelIndex;
-
-                    StringBuilder routineArrayBuilder = new StringBuilder();
-                    List<double> array = GlobalVariablesManager.GetInstance().GetVariableByName<List<double>>(GlobalVariableNames.ROUTINE_ARRAY).VariableValue;
-
-                    for (int i = 0; i < array.Count; i++)
-                    {
-                        routineArrayBuilder.Append(array[i]);
-
-                        if (i < array.Count - 1)
-                            routineArrayBuilder.Append(", ");
-                    }
-
-                    string routineArray = routineArrayBuilder.ToString();
-
-
-                    query = string.Format(
-                        "replace into {0} " +
-                        "(globalCounter, startTime, startCounterOfScans, iterationOfScan, completedScans, numberOfIterations, " +
-                        "Variables, iterators, operatingMode, startCounterOfRoutine, modelNumber, routineArray)" +
-                        "VALUES ('{1}', '{2}', '{3}', '{4}', '{5}', '{6}', '{7}', '{8}', '{9}', '{10}', '{11}', '{12}')",
-                        table, model.GlobalCounter, estimatedStartTime.ToString("yyyy-MM-dd HH:mm:ss"), StartCounterOfScansOfCurrentModel, IterationOfScan,
-                        CompletedScans, NumberOfIterations, sqlVariables, sqlIterators, currentMode.ToString(), StartGlobalCounterOfMeasurementRoutine, modelNumber, routineArray
-                        );
-
-                }
-                else // this should be removed when all experiments start using the new schema.
-                {
-                    query = "replace into " + table +
-                                   " (globalCounter, startTime, startCounterOfScans, iterationOfScan, completedScans, numberOfIterations, Variables, iterators) VALUES('" +
-                                   model.GlobalCounter + "', '" + estimatedStartTime.ToString("yyyy-MM-dd HH:mm:ss") + "', '" +
-                                   StartCounterOfScansOfCurrentModel + "', '" +
-                                   IterationOfScan + "', '" + CompletedScans + "', '" + NumberOfIterations + "', '" + sqlVariables + "', '" + sqlIterators + "')";
-                }
-                try
-                {
-                    var cmd = new MySqlCommand(query, connection);
-                    cmd.ExecuteNonQuery();
-                }
-                catch (Exception e)
-                {
-                    var errorCollector = ErrorCollector.Instance;
-                    errorCollector.AddError("Could not save to SQL database!" + e, ErrorCategory.Basic, true,
-                        ErrorTypes.FileNameEmpty);
-                    Console.WriteLine(query);
-                    Console.WriteLine(e.ToString());
-                }
-            }
-        }
-
-        /// <summary>
-        /// Queries the database for the last global counter if access to the database is allowed, otherwise returns 1
-        /// </summary>
-        /// <returns>last global counter if access to DB is allowed, 0 otherwise.</returns>
-        public int LoadGlobalCounter()
-        {
-            if (!Global.CanAccessDatabase())
-                return 0;
-
-            int globalCounter = -1;
-            DatabaseConnectionSetting setting = (DatabaseConnectionSetting)ProfilesManager.GetInstance().ActiveProfile.GetSettingByName(SettingNames.DATABASE_CONNECTION);
-            MySqlConnection connection = null;
-
-            try
-            {
-                connection = ConnectDatabase(setting);//TODO exception already handled
-            }
-            catch (Exception e)
-            {
-                var errorCollector = ErrorCollector.Instance;
-                errorCollector.AddError("Could not connect to SQL database!" + e, ErrorCategory.Basic, true,
-                    ErrorTypes.FileNameEmpty);
-            }
-
-            string table = setting.Table;
-            string query = "select globalCounter FROM " + table + " ORDER BY globalCounter DESC LIMIT 0,1";
-
-            try
-            {
-                var cmd = new MySqlCommand(query, connection);
-                globalCounter = int.Parse(cmd.ExecuteScalar() + "");
-                connection.Close();
-            }
-            catch (Exception e)
-            {
-                // FIXME - do some good error handling here
-                ErrorCollector errorCollector = ErrorCollector.Instance;
-                errorCollector.AddError("Could not load the global counter out of the SQL database!", ErrorCategory.Basic,
-                    true, ErrorTypes.FileNameEmpty);
-                Console.WriteLine(query);
-                Console.WriteLine(e.ToString());
-                //Environment.Exit(1);
-            }
-            return globalCounter;
+            return new EntryPOCO {
+                CompletedScans = CompletedScans,
+                CycleDuration = _cycleDuration,
+                EstimatedStartTime = rootModel.EstimatedStartTime,
+                GlobalCounter = rootModel.GlobalCounter,
+                IsIterating = rootModel.IsItererating,
+                IsMeasurementRoutineMode = IsMeasurementRoutineMode,
+                IterationOfScan = IterationOfScan,
+                ModelIndex = ModelIndex,
+                NumberOfIterations = NumberOfIterations,
+                StartCounterOfScansOfCurrentModel = StartCounterOfScansOfCurrentModel,
+                StartGlobalCounterOfMeasurementRoutine = StartGlobalCounterOfMeasurementRoutine,
+                VariableList = rootModel.Data.variablesModel.VariablesList 
+            };
         }
 
 
@@ -1409,12 +1225,22 @@ namespace Buffer.Basic
                         Directory.CreateDirectory(saveFolder);
                     }
 
-                    string varOut = String.Join("\r\n", model.VariablesList);
-
                     bool saveToTxtFile = profilesManager.ActiveProfile.GetSettingValueByName<bool>(SettingNames.SAVE_VARIABLES_TO_TXT);
 
                     if (saveToTxtFile)
                     {
+                        List<string> variablesList = new List<string>();
+
+                        // create list 
+                        foreach (VariableModel variable in model.Data.variablesModel.VariablesList)
+                        {
+                            if (variable.VariableName.Trim() != "")
+                            {
+                                variablesList.Add($"{variable.VariableName}\t{variable.VariableValue.ToString(CultureInfo.InvariantCulture)}");
+                            }
+                        }
+
+                        string varOut = string.Join("\r\n", variablesList);
                         File.WriteAllText(saveFolder + model.GlobalCounter + "_variables.txt", varOut.Replace(',', '.'));
                     }
 

--- a/Buffer/Buffer/Basic/OutputHandler.cs
+++ b/Buffer/Buffer/Basic/OutputHandler.cs
@@ -619,9 +619,7 @@ namespace Buffer.Basic
                 //In the first loop no data has been sent to the hardware system yet, so do not wait for the hardware.
                 if (!first)
                 {
-
                     SetOutputLoopThreadState(OutputLoopStates.WaitForHardware);
-
                     /***/
                     //Wait until all output data has been transferred to the hardware system
                     WaitForHardware();
@@ -634,7 +632,6 @@ namespace Buffer.Basic
                     //If this is the first loop, or after being stopped (user clicked on 'Stop')
                     if (first || cycleState == CycleStates.Stopped)
                     {
-
                         //If the user clicked on 'stop', iterator variables are set to their starting values.
                         if (!first)
                             //TODO check if this is necassary.
@@ -876,6 +873,7 @@ namespace Buffer.Basic
                         {
                             /***/
                             GlobalCounter++;
+                            iteratedInLastCycle = true;
                             UpdateIteratorState();
                         }
                     }

--- a/Buffer/Buffer/Buffer.csproj
+++ b/Buffer/Buffer/Buffer.csproj
@@ -94,6 +94,8 @@
   <ItemGroup>
     <Compile Include="Basic\DoubleBuffer.cs" />
     <Compile Include="Basic\OutputHandler.cs" />
+    <Compile Include="DatabaseAccess\DatabaseManager.cs" />
+    <Compile Include="DatabaseAccess\EntryPOCO.cs" />
     <Compile Include="GeneratorWrapper.cs" />
     <Compile Include="HardwareManager\NoOutputHardwareGroup.cs" />
     <Compile Include="OutputProcessors\CalibrationUnit\CalibrationScriptAnalyzer.cs" />

--- a/Buffer/Buffer/DatabaseAccess/DatabaseManager.cs
+++ b/Buffer/Buffer/DatabaseAccess/DatabaseManager.cs
@@ -1,0 +1,213 @@
+﻿using Errors.Error;
+using Model.MeasurementRoutine.GlobalVariables;
+using Model.Root;
+using Model.Settings;
+using Model.Settings.Settings;
+using Model.Variables;
+using MySql.Data.MySqlClient;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static Buffer.Basic.OutputHandler;
+
+namespace Buffer.DatabaseAccess
+{
+    class DatabaseManager
+    {
+        private const char KEY_VAL_SEP = '\t';
+
+        //  *********************************** database **********************************************************        
+        /// <summary>
+        /// Opens a connection with the MySql database.
+        /// </summary>
+        /// <param name="setting">The setting that holds the connection parameters.</param>
+        /// <returns>An open connection to the database.</returns>
+        private MySqlConnection ConnectDatabase(DatabaseConnectionSetting setting)//TODO probably should use the "using" model of connection; safer!
+        {
+            string server = setting.Server;
+            string database = setting.Database;
+            string uid = setting.UserName;
+            string password = setting.Password;
+            string port = setting.Port.ToString();
+
+            string connectionString = "SERVER=" + server + ";PORT=" + port + ";DATABASE=" +
+                                     database + ";UID=" + uid + ";PASSWORD=" + password + ";SslMode=none;";
+            MySqlConnection connection = null;
+
+            try
+            {
+                connection = new MySqlConnection(connectionString);
+                connection.Open();
+            }
+            catch (Exception e)
+            {
+                var errorCollector = ErrorCollector.Instance;
+                errorCollector.AddError("Could not connect to SQL database!" + e, ErrorCategory.Basic, true,
+                    ErrorTypes.FileNameEmpty);
+            }
+
+            return connection;
+        }
+
+        /// <summary>
+        /// Saves the variables and the scan progress/settings to the database
+        /// </summary>
+        /// <param name="model">the model</param>
+        public void CreateDatabaseEntry(EntryPOCO entry)
+        {
+            List<string> variablesList = new List<string>();
+            List<string> iteratorList = new List<string>();
+
+            // create list 
+            foreach (VariableModel variable in entry.VariableList)
+            {
+                if (variable.VariableName.Trim() != "")
+                {
+                    variablesList.Add($"{variable.VariableName}{KEY_VAL_SEP}{variable.VariableValue.ToString(CultureInfo.InvariantCulture)}");
+
+                    if (variable.IsIterator())
+                    {
+                        iteratorList.Add($"{variable.VariableName}{KEY_VAL_SEP}{variable.VariableValue.ToString(CultureInfo.InvariantCulture)}{KEY_VAL_SEP}{variable.VariableStartValue.ToString(CultureInfo.InvariantCulture)}{KEY_VAL_SEP}{variable.VariableEndValue.ToString(CultureInfo.InvariantCulture)}{KEY_VAL_SEP}{variable.VariableStepValue.ToString(CultureInfo.InvariantCulture)}");
+                    }
+                }
+            }
+
+
+            // add additional variables
+            variablesList.Add($"cntGlobal{KEY_VAL_SEP}{entry.GlobalCounter}");
+            variablesList.Add($"StartCounterOfScans{KEY_VAL_SEP}{entry.StartCounterOfScansOfCurrentModel}");
+            variablesList.Add($"StartCounterOfRoutine{KEY_VAL_SEP}{entry.StartGlobalCounterOfMeasurementRoutine}");
+
+            // variablesList.Add("StartCounterOfScans" + "\t" + StartCounterOfScans);
+            variablesList.Add($"IterationOfScan{KEY_VAL_SEP}{entry.IterationOfScan}");
+            variablesList.Add($"CompletedScans{KEY_VAL_SEP}{entry.CompletedScans}");
+            variablesList.Add($"NumberOfIterations{KEY_VAL_SEP}{entry.NumberOfIterations}");
+            variablesList.Add($"CycleDuration{KEY_VAL_SEP}{entry.CycleDuration.ToString(CultureInfo.InvariantCulture)}");
+
+            //ADDED Ghareeb 05.10.2016 do not try any access to DB if not allowed
+            if (Global.CanAccessDatabase())
+            {
+                DatabaseConnectionSetting setting = (DatabaseConnectionSetting)ProfilesManager.GetInstance().ActiveProfile.GetSettingByName(SettingNames.DATABASE_CONNECTION);
+                //save to sql database
+                string sqlVariables = string.Join("\n", variablesList);
+                string sqlIterators = string.Join("\n", iteratorList);
+
+                using (MySqlConnection connection = ConnectDatabase(setting))
+                {
+                    string table = setting.Table;
+                    DateTime estimatedStartTime = entry.EstimatedStartTime;
+                    string query = "";
+
+                    if (!ProfilesManager.GetInstance().ActiveProfile.GetSettingValueByName<bool>(SettingNames.USE_LEGACY_DATABASE))//We need to use new schema
+                    {
+                        OperatingMode currentMode;
+
+                        if (entry.IsMeasurementRoutineMode)
+                        {
+                            currentMode = OperatingMode.MEASUREMENT_ROUTINE;
+                        }
+                        else if (entry.IsIterating)
+                        {
+                            currentMode = OperatingMode.ITERATION;
+                        }
+                        else
+                        {
+                            currentMode = OperatingMode.STATIC;
+                        }
+
+                        int modelNumber = entry.ModelIndex;
+
+                        StringBuilder routineArrayBuilder = new StringBuilder();
+                        List<double> array = GlobalVariablesManager.GetInstance().GetVariableByName<List<double>>(GlobalVariableNames.ROUTINE_ARRAY).VariableValue;
+
+                        for (int i = 0; i < array.Count; i++)
+                        {
+                            routineArrayBuilder.Append(array[i]);
+
+                            if (i < array.Count - 1)
+                                routineArrayBuilder.Append(", ");
+                        }
+
+                        string routineArray = routineArrayBuilder.ToString();
+
+
+                        query = string.Format(
+                            "replace into {0} " +
+                            "(globalCounter, startTime, startCounterOfScans, iterationOfScan, completedScans, numberOfIterations, " +
+                            "Variables, iterators, operatingMode, startCounterOfRoutine, modelNumber, routineArray)" +
+                            "VALUES ('{1}', '{2}', '{3}', '{4}', '{5}', '{6}', '{7}', '{8}', '{9}', '{10}', '{11}', '{12}')",
+                            table, entry.GlobalCounter, estimatedStartTime.ToString("yyyy-MM-dd HH:mm:ss"), entry.StartCounterOfScansOfCurrentModel, entry.IterationOfScan,
+                            entry.CompletedScans, entry.NumberOfIterations, sqlVariables, sqlIterators, currentMode.ToString(), entry.StartGlobalCounterOfMeasurementRoutine, modelNumber, routineArray
+                            );
+
+                    }
+                    else // this should be removed when all experiments start using the new schema.
+                    {
+                        query = "replace into " + table +
+                                       " (globalCounter, startTime, startCounterOfScans, iterationOfScan, completedScans, numberOfIterations, Variables, iterators) VALUES('" +
+                                       entry.GlobalCounter + "', '" + estimatedStartTime.ToString("yyyy-MM-dd HH:mm:ss") + "', '" +
+                                       entry.StartCounterOfScansOfCurrentModel + "', '" +
+                                       entry.IterationOfScan + "', '" + entry.CompletedScans + "', '" + entry.NumberOfIterations + "', '" + sqlVariables + "', '" + sqlIterators + "')";
+                    }
+                    try
+                    {
+                        using (var cmd = new MySqlCommand(query, connection))
+                        {
+                            cmd.ExecuteNonQuery();
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        var errorCollector = ErrorCollector.Instance;
+                        errorCollector.AddError("Could not save to SQL database!" + e, ErrorCategory.Basic, true,
+                            ErrorTypes.FileNameEmpty);
+                        Console.WriteLine(query);
+                        Console.WriteLine(e.ToString());
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Queries the database for the last global counter if access to the database is allowed, otherwise returns 1
+        /// </summary>
+        /// <returns>last global counter if access to DB is allowed, 0 otherwise.</returns>
+        public int LoadGlobalCounter()
+        {
+            if (!Global.CanAccessDatabase())
+                return 0;
+
+            int globalCounter = -1;
+            DatabaseConnectionSetting setting = (DatabaseConnectionSetting)ProfilesManager.GetInstance().ActiveProfile.GetSettingByName(SettingNames.DATABASE_CONNECTION);
+            MySqlConnection connection = null;
+
+
+            using (connection = ConnectDatabase(setting))
+            {
+                string table = setting.Table;
+                string query = "select globalCounter FROM " + table + " ORDER BY globalCounter DESC LIMIT 0,1";
+
+                try
+                {
+                    using (var cmd = new MySqlCommand(query, connection))
+                    {
+                        globalCounter = int.Parse(cmd.ExecuteScalar() + "");
+                    }
+                }
+                catch (Exception e)
+                {
+                    ErrorCollector errorCollector = ErrorCollector.Instance;
+                    errorCollector.AddError("Could not load the global counter out of the SQL database!", ErrorCategory.Basic,
+                        true, ErrorTypes.FileNameEmpty);
+                    Console.WriteLine(query);
+                    Console.WriteLine(e.ToString());
+                }
+            }
+
+            return globalCounter;
+        }
+    }
+}

--- a/Buffer/Buffer/DatabaseAccess/EntryPOCO.cs
+++ b/Buffer/Buffer/DatabaseAccess/EntryPOCO.cs
@@ -1,0 +1,26 @@
+﻿using Model.Variables;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Buffer.DatabaseAccess
+{
+    public class EntryPOCO
+    {
+        public int GlobalCounter { set; get; }
+        public int StartCounterOfScansOfCurrentModel { set; get; }
+        public int StartGlobalCounterOfMeasurementRoutine { set; get; }
+        public int IterationOfScan { set; get; }
+        public int CompletedScans { set; get; }
+        public int NumberOfIterations { set; get; }
+        public double CycleDuration { set; get; }
+        public bool IsMeasurementRoutineMode { set; get; }
+        public bool IsIterating { set; get; }
+        public int ModelIndex { set; get; }
+
+        public List<VariableModel> VariableList { set; get; }
+        public DateTime EstimatedStartTime { set; get; }
+    }
+}

--- a/Controller/Controller/MainWindow/IterationManagerController.cs
+++ b/Controller/Controller/MainWindow/IterationManagerController.cs
@@ -5,6 +5,18 @@ namespace Controller.MainWindow
 {
     public class IterationManagerController : ChildController
     {
+        private bool _isScanOnlyOnceEnabled = true;
+        private bool _isStopAfterScanEnabled = true;
+        private bool _isShuffleIterationsEnabled = true;
+        private string _nameOfTheCurrentStartGCOfScans = "Current Start GC of Scans:";
+        private Visibility _isPreviousStartGCOfScansVisible = Visibility.Visible;
+
+        public IterationManagerController(MainWindowController parent)
+            : base(parent)
+        {
+        }
+
+
         private MainWindowController Parent
         {
             get
@@ -14,8 +26,6 @@ namespace Controller.MainWindow
         }
 
         public ICommand ScanOnlyOnceCommand { get { return Parent.OnlyOnceCommand; } }
-
-        private bool _isScanOnlyOnceEnabled = true;
 
         public bool IsScanOnlyOnceEnabled
         {
@@ -38,7 +48,7 @@ namespace Controller.MainWindow
             }
         }
 
-        private bool _isStopAfterScanEnabled = true;
+
         public bool IsStopAfterScanEnabled
         {
             get
@@ -63,7 +73,6 @@ namespace Controller.MainWindow
             }
         }
 
-        private bool _isShuffleIterationsEnabled = true;
 
         public bool IsShuffleIterationsEnabled
         {
@@ -88,17 +97,6 @@ namespace Controller.MainWindow
             }
         }
 
-        private bool _isPauseEnabled = true;
-
-        public bool IsPauseEnabled
-        {
-            get { return _isPauseEnabled; }
-            set
-            {
-                _isPauseEnabled = value;
-                OnPropertyChanged("IsPauseEnabled");
-            }
-        }
         public bool IsOnceChecked
         {
             get
@@ -132,17 +130,12 @@ namespace Controller.MainWindow
             get { return Parent.IterationOfScan; }
         }
 
-        //public int IterationOfScan
-        //{
-        //    get { return Parent.MeasurementRoutineController.CurrentRoutineModel.RoutineModel.Counters.IterationOfScan; }
-        //}
-
         public int CompletedScans
         {
             get { return Parent.CompletedScans; }
         }
 
-        private string _nameOfTheCurrentStartGCOfScans = "Current Start GC of Scans:";
+
         public string NameOfTheCurrentStartGCOfScans
         {
             get { return _nameOfTheCurrentStartGCOfScans; }
@@ -151,20 +144,17 @@ namespace Controller.MainWindow
                 _nameOfTheCurrentStartGCOfScans = value;
                 OnPropertyChanged("NameOfTheCurrentStartGCOfScans");
             }
-    }
+        }
 
-        private Visibility _isPreviousStartGCOfScansVisible=Visibility.Visible;
 
         public Visibility IsPreviousStartGCOfScansVisible
         {
             get { return _isPreviousStartGCOfScansVisible; }
-            set { _isPreviousStartGCOfScansVisible = value;
-            OnPropertyChanged("IsPreviousStartGCOfScansVisible");
+            set
+            {
+                _isPreviousStartGCOfScansVisible = value;
+                OnPropertyChanged("IsPreviousStartGCOfScansVisible");
             }
-        }
-        public IterationManagerController(MainWindowController parent)
-            : base(parent)
-        {
         }
 
     }

--- a/Controller/Controller/MainWindow/IterationManagerController.cs
+++ b/Controller/Controller/MainWindow/IterationManagerController.cs
@@ -74,29 +74,7 @@ namespace Controller.MainWindow
                 OnPropertyChanged("IsShuffleIterationsEnabled");
             }
         }
-        public bool AlwaysIncrease
-        {
-            set
-            {
-                Parent.AlwaysIncrease = value;
-            }
 
-            get
-            {
-                return Parent.AlwaysIncrease;
-            }
-        }
-        private bool _isAlwaysIncreaseEnabled = true;
-
-        public bool IsAlwaysIncreaseEnabled
-        {
-            get { return _isAlwaysIncreaseEnabled; }
-            set
-            {
-                _isAlwaysIncreaseEnabled = value;
-                OnPropertyChanged("IsAlwaysIncreaseEnabled");
-            }
-        }
         public bool Pause
         {
             set
@@ -110,7 +88,7 @@ namespace Controller.MainWindow
             }
         }
 
-        private bool _isPauseEnabled;
+        private bool _isPauseEnabled = true;
 
         public bool IsPauseEnabled
         {
@@ -123,12 +101,10 @@ namespace Controller.MainWindow
         }
         public bool IsOnceChecked
         {
-
             get
             {
                 return Parent.IsOnceChecked;
             }
-
         }
 
 

--- a/Controller/Controller/MainWindow/MainWindowController.cs
+++ b/Controller/Controller/MainWindow/MainWindowController.cs
@@ -582,7 +582,7 @@ namespace Controller.MainWindow
 
         public bool IsAlwaysIncreaseEnabled
         {
-            get { return _isAlwaysIncreaseEnabled; }
+            get { return _isAlwaysIncreaseEnabled && !IsIterateAndSaveChecked; }
             set
             {
                 _isAlwaysIncreaseEnabled = value;
@@ -1276,6 +1276,7 @@ namespace Controller.MainWindow
             _iterateAndSave = !_iterateAndSave;
             OnPropertyChanged("IsIterateAndSaveChecked");
             OnPropertyChanged("IsPauseEnabled");
+            OnPropertyChanged("IsAlwaysIncreaseEnabled");
             DetermineCycleState();
         }
 

--- a/Controller/Controller/MainWindow/MainWindowController.cs
+++ b/Controller/Controller/MainWindow/MainWindowController.cs
@@ -111,6 +111,7 @@ namespace Controller.MainWindow
         /// Indicates whether the fifo debug window is open
         /// </summary>
         private bool isFifoDebugWindowOpen;
+        private bool _isAlwaysIncreaseEnabled = true;
         #endregion
 
         // ********************* Properties ****************************************
@@ -559,6 +560,16 @@ namespace Controller.MainWindow
         {
             get { return _outputHandler.alwaysIncrease; }
             set { _outputHandler.alwaysIncrease = value; }
+        }
+
+        public bool IsAlwaysIncreaseEnabled
+        {
+            get { return _isAlwaysIncreaseEnabled; }
+            set
+            {
+                _isAlwaysIncreaseEnabled = value;
+                OnPropertyChanged("IsAlwaysIncreaseEnabled");
+            }
         }
 
         public bool IsOnceChecked
@@ -1682,7 +1693,7 @@ namespace Controller.MainWindow
                 IterationManagerController.IsStopAfterScanEnabled = false;
                 IterationManagerController.IsShuffleIterationsEnabled = false;
                 IterationManagerController.IsPauseEnabled = false;
-                IterationManagerController.IsAlwaysIncreaseEnabled = false;
+                IsAlwaysIncreaseEnabled = false;
 
 
             }
@@ -1703,7 +1714,7 @@ namespace Controller.MainWindow
                 IterationManagerController.IsStopAfterScanEnabled = true;
                 IterationManagerController.IsShuffleIterationsEnabled = true;
                 IterationManagerController.IsPauseEnabled = true;
-                IterationManagerController.IsAlwaysIncreaseEnabled = true;
+                IsAlwaysIncreaseEnabled = true;
             }
         }
         #endregion

--- a/Controller/Controller/MainWindow/MainWindowController.cs
+++ b/Controller/Controller/MainWindow/MainWindowController.cs
@@ -112,6 +112,7 @@ namespace Controller.MainWindow
         /// </summary>
         private bool isFifoDebugWindowOpen;
         private bool _isAlwaysIncreaseEnabled = true;
+        private bool _isPauseEnabled = true;
         #endregion
 
         // ********************* Properties ****************************************
@@ -544,6 +545,19 @@ namespace Controller.MainWindow
             }
         }
 
+        public bool IsPauseEnabled
+        {
+            get
+            {
+                return _isPauseEnabled && (AlwaysIncrease || IsIterateAndSaveChecked);
+            }
+            set
+            {
+                _isPauseEnabled = value;
+                OnPropertyChanged("IsPauseEnabled");
+            }
+        }
+
         public bool ShuffleIterations
         {
             get { return _outputHandler.shuffleIterations; }
@@ -559,7 +573,11 @@ namespace Controller.MainWindow
         public bool AlwaysIncrease
         {
             get { return _outputHandler.alwaysIncrease; }
-            set { _outputHandler.alwaysIncrease = value; }
+            set
+            {
+                _outputHandler.alwaysIncrease = value;
+                OnPropertyChanged("IsPauseEnabled"); 
+            }
         }
 
         public bool IsAlwaysIncreaseEnabled
@@ -591,6 +609,7 @@ namespace Controller.MainWindow
             {
                 _iterateAndSave = value;
                 OnPropertyChanged("IsIterateAndSaveChecked");
+                OnPropertyChanged("IsPauseEnabled");
             }
         }
 
@@ -1084,8 +1103,8 @@ namespace Controller.MainWindow
                         UnblockUI();
                         OptionsManager.GetInstance().GetValuesFromCopy(controller.OptionsCopy);
                         OptionsManager.GetInstance().SaveOptions();
-                        //We can restart immediately
-                        RestartApplication();
+                    //We can restart immediately
+                    RestartApplication();
 
                     };
                     //set the IsBusy before you start the thread
@@ -1150,8 +1169,8 @@ namespace Controller.MainWindow
                         UnblockUI();
                         ProfilesManager.GetInstance().GetValuesFromSnapshot(controller.SettingsSnapshot);
                         ProfilesManager.GetInstance().SaveAllProfiles();
-                        //We can restart immediately
-                        RestartApplication();
+                    //We can restart immediately
+                    RestartApplication();
 
                     };
                     //set the IsBusy before you start the thread
@@ -1256,6 +1275,7 @@ namespace Controller.MainWindow
         {
             _iterateAndSave = !_iterateAndSave;
             OnPropertyChanged("IsIterateAndSaveChecked");
+            OnPropertyChanged("IsPauseEnabled");
             DetermineCycleState();
         }
 
@@ -1334,7 +1354,7 @@ namespace Controller.MainWindow
             }
 
         }
-        
+
         public void ShutdownApplication(object parameter)
         {
             CancelEventArgs e = (CancelEventArgs)parameter;
@@ -1470,10 +1490,10 @@ namespace Controller.MainWindow
                 handler =
                     new DoubleBuffer.FinishedModelGenerationEventHandler((sender, args) =>
                     {
-                        //trigger the callback
-                        callback(args);
-                        //stop receiving new events
-                        _buffer.FinishedModelGeneration -= handler;
+                    //trigger the callback
+                    callback(args);
+                    //stop receiving new events
+                    _buffer.FinishedModelGeneration -= handler;
                     });
 
                 _buffer.FinishedModelGeneration += handler;
@@ -1692,7 +1712,7 @@ namespace Controller.MainWindow
                 IterationManagerController.IsScanOnlyOnceEnabled = false;
                 IterationManagerController.IsStopAfterScanEnabled = false;
                 IterationManagerController.IsShuffleIterationsEnabled = false;
-                IterationManagerController.IsPauseEnabled = false;
+                IsPauseEnabled = false;
                 IsAlwaysIncreaseEnabled = false;
 
 
@@ -1713,7 +1733,7 @@ namespace Controller.MainWindow
                 IterationManagerController.IsScanOnlyOnceEnabled = true;
                 IterationManagerController.IsStopAfterScanEnabled = true;
                 IterationManagerController.IsShuffleIterationsEnabled = true;
-                IterationManagerController.IsPauseEnabled = true;
+                IsPauseEnabled = true;
                 IsAlwaysIncreaseEnabled = true;
             }
         }

--- a/Controller/Controller/Settings/Settings/DatabaseConnectionSettingController.cs
+++ b/Controller/Controller/Settings/Settings/DatabaseConnectionSettingController.cs
@@ -294,36 +294,25 @@ namespace Controller.Settings.Settings
             string table = Table;
             string query = "select globalCounter FROM " + table + "  LIMIT 1;";
 
-            MySqlConnection connection = null;
+            
             string result = "The database connection is valid!";
             isValid = true;
 
             try
             {
-                connection = new MySqlConnection(connectionString);
-                connection.Open();
-                MySqlCommand cmd = new MySqlCommand(query, connection);
-                object objectResult = cmd.ExecuteScalar();
+                using (MySqlConnection connection = new MySqlConnection(connectionString))
+                {
+                    connection.Open();
+                    MySqlCommand cmd = new MySqlCommand(query, connection);
+                    cmd.ExecuteScalar();
+                }
             }
             catch (Exception e)
             {
                 result = string.Format("The database connection is invalid: {0}", e.Message);
                 isValid = false;
             }
-            finally
-            {
-                if (connection != null)
-                {
-                    try 
-                    { 
-                        connection.Close(); 
-                    }
-                    catch
-                    { }
-                }
-            }
-
-
+            
             return result;
         }
 

--- a/Model/Model/Root/RootModel.cs
+++ b/Model/Model/Root/RootModel.cs
@@ -1,6 +1,7 @@
 ﻿using Communication.Interfaces.Model;
 using Model.Data;
 using System;
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 
 
@@ -50,7 +51,8 @@ namespace Model.Root
         /// Contains the names and values of all variables used to be written to the database and to a text file.
         /// Is maintained and used by the Buffer.Basic.OutputHandler/>
         /// </summary>
-        public System.Collections.Generic.List<string> VariablesList;
+        [ObsoleteAttribute("This property is obsolete and should never be used", false)]
+        public List<string> VariablesList;
 
 
         //model-specific python scripts

--- a/View/View/Main/IterationManagerView.xaml
+++ b/View/View/Main/IterationManagerView.xaml
@@ -63,14 +63,6 @@
                 IsChecked="{Binding Pause}"
                 IsEnabled="{Binding IsPauseEnabled}" />
 
-            <CheckBox
-                Grid.Row="4"
-                HorizontalAlignment="Left"
-                VerticalAlignment="Stretch"
-                Content="Always Increase"
-                IsChecked="{Binding AlwaysIncrease}"
-                IsEnabled="{Binding IsAlwaysIncreaseEnabled}" />
-
             <!--  Column 2  -->
             <TextBlock
                 Grid.Row="0"

--- a/View/View/Main/IterationManagerView.xaml
+++ b/View/View/Main/IterationManagerView.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    d:DesignHeight="300"
+    d:DesignHeight="200"
     d:DesignWidth="400"
     mc:Ignorable="d">
     <Border
@@ -55,13 +55,7 @@
                 IsChecked="{Binding ShuffleIterations}"
                 IsEnabled="{Binding IsShuffleIterationsEnabled}" />
 
-            <CheckBox
-                Grid.Row="3"
-                HorizontalAlignment="Left"
-                VerticalAlignment="Stretch"
-                Content="Pause"
-                IsChecked="{Binding Pause}"
-                IsEnabled="{Binding IsPauseEnabled}" />
+            
 
             <!--  Column 2  -->
             <TextBlock

--- a/View/View/Main/MainWindow.xaml
+++ b/View/View/Main/MainWindow.xaml
@@ -87,6 +87,7 @@
                         <RowDefinition Height="30" />
                         <RowDefinition Height="30" />
                         <RowDefinition Height="30" />
+                        <RowDefinition Height="30" />
                         <RowDefinition Height="*" />
                     </Grid.RowDefinitions>
 
@@ -219,10 +220,17 @@
                         Content="Always Increase GC"
                         IsChecked="{Binding AlwaysIncrease}"
                         IsEnabled="{Binding IsAlwaysIncreaseEnabled}" />
-
+                    <CheckBox
+                        Grid.Row="3"
+                        HorizontalAlignment="Left"
+                        VerticalAlignment="Stretch"
+                        Margin="2,5,0,0"
+                        Content="Pause Increasing GC"
+                        IsChecked="{Binding Pause}"
+                        IsEnabled="{Binding IsPauseEnabled}" /> 
                     <CheckBox
                         Name="IterateAndSaveButton"
-                        Grid.Row="3"
+                        Grid.Row="4"
                         Grid.Column="0"
                         Grid.ColumnSpan="3"
                         Margin="2,5,0,0"
@@ -234,7 +242,7 @@
                         IsEnabled="{Binding IncrementIteratorsIsEnabled, Mode=TwoWay}" />
 
                     <ContentControl
-                        Grid.Row="4"
+                        Grid.Row="5"
                         Grid.Column="0"
                         Grid.ColumnSpan="4"
                         Content="{Binding IterationManagerController}"

--- a/View/View/Main/MainWindow.xaml
+++ b/View/View/Main/MainWindow.xaml
@@ -86,6 +86,7 @@
                         <RowDefinition Height="auto" />
                         <RowDefinition Height="30" />
                         <RowDefinition Height="30" />
+                        <RowDefinition Height="30" />
                         <RowDefinition Height="*" />
                     </Grid.RowDefinitions>
 
@@ -208,10 +209,20 @@
                         Content="Control LeCroy"
                         IsChecked="{Binding ControlLecroy}"
                         IsEnabled="{Binding IsControlLecroyPossible}" />
+                    <CheckBox
+                        Grid.Row="2"
+                        Grid.Column="0"
+                        Grid.ColumnSpan="3"
+                        Margin="2,5,0,0"
+                        HorizontalAlignment="Left"
+                        VerticalAlignment="Stretch"
+                        Content="Always Increase GC"
+                        IsChecked="{Binding AlwaysIncrease}"
+                        IsEnabled="{Binding IsAlwaysIncreaseEnabled}" />
 
                     <CheckBox
                         Name="IterateAndSaveButton"
-                        Grid.Row="2"
+                        Grid.Row="3"
                         Grid.Column="0"
                         Grid.ColumnSpan="3"
                         Margin="2,5,0,0"
@@ -223,7 +234,7 @@
                         IsEnabled="{Binding IncrementIteratorsIsEnabled, Mode=TwoWay}" />
 
                     <ContentControl
-                        Grid.Row="3"
+                        Grid.Row="4"
                         Grid.Column="0"
                         Grid.ColumnSpan="4"
                         Content="{Binding IterationManagerController}"

--- a/View/View/Main/MeasurementRoutineManagerView.xaml
+++ b/View/View/Main/MeasurementRoutineManagerView.xaml
@@ -145,7 +145,7 @@
                     HorizontalAlignment="Left"
                     Content="Advanced Mode"
                     IsChecked="{Binding IsAdvancedMode}"
-                    IsEnabled="{Binding Allowed, Mode=OneTime}" />
+                    IsEnabled="{Binding IsAdvancedModeAllowed, Mode=OneTime}" />
 
                 <Grid Grid.Row="5" Visibility="{Binding AdvancedModeVisibility}">
                     <Grid.RowDefinitions>


### PR DESCRIPTION
- Ensure that the GC is increased exactly once even if the option to always increase the GC is checked and one or more model changes occur (e.g., a change to a variable's value).
- Factor out the code to communicate with the underlying database from the `OutputHandler` class (related to issue #28 ).
- Decouple the option to `AlwaysIncrease` the global counter from the option to increase iterators.
- Decouple the option to `Pause` the increments of the global counter from the option to increase iterators (since it could be used when `AlwaysIncrease` is checked).
- If the option to increment the iterators is checked, the option to `AlwaysIncrease` is disabled since it becomes useless.
- If neither `AlwaysIncrease` nor the option to increment iterators are unchecked, then the option to `Pause` GC increments is disabled since it becomes irrelevant.
- Closes #44 .

![image](https://user-images.githubusercontent.com/28387669/121069713-1ab21180-c7ce-11eb-9c49-2421e14ebdd3.png)

![image](https://user-images.githubusercontent.com/28387669/121069720-1d146b80-c7ce-11eb-8d82-a518b588cd62.png)


![image](https://user-images.githubusercontent.com/28387669/121069728-1e459880-c7ce-11eb-9a1f-b4a2acd8c409.png)
