### PR TITLE
Add automatic CI pipeline for running unit tests on every push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,13 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
+      with:
+        repository: coldphysics/private_dlls
+        path: './private_dlls'
+        ssh-key: ${{ secrets.DLL_ACCESS_KEY }}
+  
+    - name: Move private DLLs
+      run: mv ./private_dlls/lib/*.dll ./libs
 
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,4 +31,4 @@ jobs:
       uses: microsoft/vstest-action@v1.0.0
       with:
         testAssembly: GeneratorUT.dll
-        searchFolder: .\GeneratorUT\bin\Debug\
+        searchFolder: .\experiment-control\GeneratorUT\bin\Debug\

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
+      
+    - name: Pull private DLLs
+      uses: actions/checkout@v2
       with:
         repository: coldphysics/private_dlls
         path: './private_dlls'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       uses: microsoft/setup-msbuild@v1.1
 
     - name: Restore packages
-      run: msbuild MainProject\ExperimentControl.sln -t:restore
+      run: msbuild MainProject\ExperimentControl.sln -t:Restore -p:RestorePackagesConfig=true
 
     - name: Build
       run: msbuild MainProject\ExperimentControl.sln -property:Configuration=Debug;Platform=x64 -t:build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,24 @@ on: [push]
 jobs:
   test:
     runs-on: windows-2019
-    env:
-      Test_Project_Path: GeneratorUT\GeneratorUT.csproj
     steps:
-    - name: Checkout
+    - name: Checkout code
       uses: actions/checkout@v2
-    - name: Execute unit tests
-      run: dotnet test $env:Test_Project_Path
+
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1.1
+
+    - name: Setup NuGet
+      uses: nuget/setup-nuget@v1
+
+    - name: Restore packages
+      run: msbuild MainProject\ExperimentControl.sln -t:restore
+
+    - name: Build
+      run: msbuild MainProject\ExperimentControl.sln -property:Configuration=Debug;Platform=x64 -t:build
+      
+    - name: Run tests
+      uses: microsoft-approved-actions/vstest@master
+      with:
+        testAssembly: GeneratorUT.dll
+        searchFolder: .\GeneratorUT\bin\Debug\

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,12 @@
 run-name: Tests for the experiment control software are being run
 on: [push]
 jobs:
-  build:
+  test:
     runs-on: windows-2019
+    env:
+      Test_Project_Path: GeneratorUT\GeneratorUT.csproj
     steps:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Execute unit tests
-      run: dotnet test GeneratorUT\GeneratorUT.csproj
+      run: dotnet test $env:Test_Project_Path

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       run: msbuild MainProject\ExperimentControl.sln -t:Restore -p:RestorePackagesConfig=true
 
     - name: Build
-      run: msbuild MainProject\ExperimentControl.sln -property:Configuration=Debug;Platform=x64 -t:build
+      run: msbuild MainProject\ExperimentControl.sln -property:Configuration=Debug`;Platform=x64 -t:build
       
     - name: Run tests
       uses: microsoft/vstest-action@v1.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,6 @@ jobs:
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.1
 
-    - name: Setup NuGet
-      uses: nuget/setup-nuget@v1
-
     - name: Restore packages
       run: msbuild MainProject\ExperimentControl.sln -t:restore
 
@@ -21,7 +18,7 @@ jobs:
       run: msbuild MainProject\ExperimentControl.sln -property:Configuration=Debug;Platform=x64 -t:build
       
     - name: Run tests
-      uses: microsoft/vstest@v1.2.0
+      uses: microsoft/vstest@latest
       with:
         testAssembly: GeneratorUT.dll
         searchFolder: .\GeneratorUT\bin\Debug\

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-﻿name: Test
+name: Test
 run-name: Tests for the experiment control software are being run
 on: [push]
 jobs:
@@ -7,6 +7,9 @@ jobs:
     steps:
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.1
+      
+    - name: Add vstest to path
+      uses: darenm/Setup-VSTest@v1.2
       
     - name: Checkout code
       uses: actions/checkout@v2
@@ -28,7 +31,4 @@ jobs:
       run: msbuild MainProject\ExperimentControl.sln -property:Configuration=Debug`;Platform=x64 -t:build
       
     - name: Run tests
-      uses: microsoft/vstest-action@v1.0.0
-      with:
-        testAssembly: GeneratorUT.dll
-        searchFolder: .\GeneratorUT\bin\x64\Debug\
+      run: vstest.console GeneratorUT\bin\x64\Debug\GeneratorUT.dll

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,12 @@ jobs:
   test:
     runs-on: windows-2019
     steps:
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1.1
+      
+    - name: Add vstest to path
+      uses: darenm/Setup-VSTest@v1.2
+      
     - name: Checkout code
       uses: actions/checkout@v2
       
@@ -17,9 +23,6 @@ jobs:
   
     - name: Move private DLLs
       run: cp -force ./private_dlls/libs/*.dll ./libs
-
-    - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.1
 
     - name: Restore packages
       run: msbuild MainProject\ExperimentControl.sln -t:Restore -p:RestorePackagesConfig=true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       run: msbuild MainProject\ExperimentControl.sln -property:Configuration=Debug;Platform=x64 -t:build
       
     - name: Run tests
-      uses: microsoft/vstest@latest
+      uses: microsoft/vstest
       with:
         testAssembly: GeneratorUT.dll
         searchFolder: .\GeneratorUT\bin\Debug\

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,5 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Install .NET Core
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: '4.8.x'
     - name: Execute unit tests
       run: dotnet test GeneratorUT\GeneratorUT.csproj

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         ssh-key: ${{ secrets.DLL_ACCESS_KEY }}
   
     - name: Move private DLLs
-      run: mv ./private_dlls/lib/*.dll ./libs
+      run: mv ./private_dlls/libs/*.dll ./libs
 
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,4 +31,4 @@ jobs:
       uses: microsoft/vstest-action@v1.0.0
       with:
         testAssembly: GeneratorUT.dll
-        searchFolder: .\experiment-control\GeneratorUT\bin\Debug\
+        searchFolder: ./experiment-control/GeneratorUT/bin/Debug/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         ssh-key: ${{ secrets.DLL_ACCESS_KEY }}
   
     - name: Move private DLLs
-      run: cp -f ./private_dlls/libs/*.dll ./libs
+      run: cp -force ./private_dlls/libs/*.dll ./libs
 
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,4 +31,4 @@ jobs:
       run: msbuild MainProject\ExperimentControl.sln -property:Configuration=Debug`;Platform=x64 -t:build
       
     - name: Run tests
-      run: vstest.console GeneratorUT\bin\Debug\GeneratorUT.dll
+      run: vstest.console GeneratorUT\bin\x64\Debug\GeneratorUT.dll

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+﻿name: Test
+run-name: Tests for the experiment control software are being run
+on: [push]
+jobs:
+  build:
+    runs-on: windows-2019
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install .NET Core
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '4.8.x'
+    - name: Execute unit tests
+      run: dotnet test GeneratorUT\GeneratorUT.csproj

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       run: msbuild MainProject\ExperimentControl.sln -property:Configuration=Debug;Platform=x64 -t:build
       
     - name: Run tests
-      uses: microsoft/vstest
+      uses: microsoft/vstest@v1.0.0
       with:
         testAssembly: GeneratorUT.dll
         searchFolder: .\GeneratorUT\bin\Debug\

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,4 @@ jobs:
       run: msbuild MainProject\ExperimentControl.sln -property:Configuration=Debug`;Platform=x64 -t:build
       
     - name: Run tests
-      uses: microsoft/vstest-action@v1.0.0
-      with:
-        testAssembly: GeneratorUT.dll
-        searchFolder: ./experiment-control/GeneratorUT/bin/Debug/
+      run: vstest.console GeneratorUT\bin\Debug\GeneratorUT.dll

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,6 @@ jobs:
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.1
       
-    - name: Add vstest to path
-      uses: darenm/Setup-VSTest@v1.2
-      
     - name: Checkout code
       uses: actions/checkout@v2
       
@@ -31,4 +28,7 @@ jobs:
       run: msbuild MainProject\ExperimentControl.sln -property:Configuration=Debug`;Platform=x64 -t:build
       
     - name: Run tests
-      run: vstest.console GeneratorUT\bin\x64\Debug\GeneratorUT.dll
+      uses: microsoft/vstest-action@v1.0.0
+      with:
+        testAssembly: GeneratorUT.dll
+        searchFolder: .\GeneratorUT\bin\x64\Debug\

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       run: msbuild MainProject\ExperimentControl.sln -property:Configuration=Debug;Platform=x64 -t:build
       
     - name: Run tests
-      uses: microsoft-approved-actions/vstest@master
+      uses: microsoft/vstest@v1.2.0
       with:
         testAssembly: GeneratorUT.dll
         searchFolder: .\GeneratorUT\bin\Debug\

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       run: msbuild MainProject\ExperimentControl.sln -property:Configuration=Debug;Platform=x64 -t:build
       
     - name: Run tests
-      uses: microsoft/vstest@v1.0.0
+      uses: microsoft/vstest-action@v1.0.0
       with:
         testAssembly: GeneratorUT.dll
         searchFolder: .\GeneratorUT\bin\Debug\

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         ssh-key: ${{ secrets.DLL_ACCESS_KEY }}
   
     - name: Move private DLLs
-      run: mv ./private_dlls/libs/*.dll ./libs
+      run: cp -f ./private_dlls/libs/*.dll ./libs
 
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.1

--- a/GeneratorUT/DoubleBufferUT.cs
+++ b/GeneratorUT/DoubleBufferUT.cs
@@ -33,10 +33,7 @@ namespace GeneratorUT
                 Assert.IsTrue(DoubleEquals(output.OutputDurationMillis * timesToReplicate / 1000.0, buffer.DurationSeconds));
             };
 
-            buffer.CopyData(model, timesToReplicate);
-
-            Assert.IsTrue(false);
-            
+            buffer.CopyData(model, timesToReplicate);            
         }
     }
 }

--- a/GeneratorUT/DoubleBufferUT.cs
+++ b/GeneratorUT/DoubleBufferUT.cs
@@ -17,6 +17,7 @@ namespace GeneratorUT
         [DataTestMethod]
         public void TestRegularOutputDurationWithReplication(string modelName, string profileName)
         {
+            SelectProfile(profileName);
             const int timesToReplicate = 3;
             RootModel model = base.LoadModel(modelName);
             ModelBuilder modelBuilder = new ModelBuilder(); 

--- a/GeneratorUT/DoubleBufferUT.cs
+++ b/GeneratorUT/DoubleBufferUT.cs
@@ -34,6 +34,8 @@ namespace GeneratorUT
             };
 
             buffer.CopyData(model, timesToReplicate);
+
+            Assert.IsTrue(false);
             
         }
     }

--- a/MainProject/ExperimentControl.sln
+++ b/MainProject/ExperimentControl.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2009
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.34003.232
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AbstractController", "..\AbstractController\AbstractController\AbstractController.csproj", "{729D4737-0773-440F-B79E-5CE13C39E8A8}"
 EndProject
@@ -548,8 +548,8 @@ Global
 		{B96AEE3A-ECD0-4937-A5B7-999A111726D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B96AEE3A-ECD0-4937-A5B7-999A111726D1}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
 		{B96AEE3A-ECD0-4937-A5B7-999A111726D1}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{B96AEE3A-ECD0-4937-A5B7-999A111726D1}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{B96AEE3A-ECD0-4937-A5B7-999A111726D1}.Debug|x64.Build.0 = Debug|Any CPU
+		{B96AEE3A-ECD0-4937-A5B7-999A111726D1}.Debug|x64.ActiveCfg = Debug|x64
+		{B96AEE3A-ECD0-4937-A5B7-999A111726D1}.Debug|x64.Build.0 = Debug|x64
 		{B96AEE3A-ECD0-4937-A5B7-999A111726D1}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{B96AEE3A-ECD0-4937-A5B7-999A111726D1}.Debug|x86.Build.0 = Debug|Any CPU
 		{B96AEE3A-ECD0-4937-A5B7-999A111726D1}.DVD-5|Any CPU.ActiveCfg = Debug|Any CPU
@@ -564,8 +564,8 @@ Global
 		{B96AEE3A-ECD0-4937-A5B7-999A111726D1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B96AEE3A-ECD0-4937-A5B7-999A111726D1}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{B96AEE3A-ECD0-4937-A5B7-999A111726D1}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{B96AEE3A-ECD0-4937-A5B7-999A111726D1}.Release|x64.ActiveCfg = Release|Any CPU
-		{B96AEE3A-ECD0-4937-A5B7-999A111726D1}.Release|x64.Build.0 = Release|Any CPU
+		{B96AEE3A-ECD0-4937-A5B7-999A111726D1}.Release|x64.ActiveCfg = Release|x64
+		{B96AEE3A-ECD0-4937-A5B7-999A111726D1}.Release|x64.Build.0 = Release|x64
 		{B96AEE3A-ECD0-4937-A5B7-999A111726D1}.Release|x86.ActiveCfg = Release|Any CPU
 		{B96AEE3A-ECD0-4937-A5B7-999A111726D1}.Release|x86.Build.0 = Release|Any CPU
 		{B96AEE3A-ECD0-4937-A5B7-999A111726D1}.SingleImage|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
Running all unit tests on every push ensures that any failures are immediately noticed, making the tests actually useful for ensuring the software's quality.

The build is implemented such that it obtains the copyrighted DLLs necessary from the private repository where they reside. This is done using a deploy key that is stored as a secret in this repository. Since no artifacts are saved and secrets are not available to actions running on forked repositories, this does NOT make the DLLs publicly available.